### PR TITLE
fix: align MCP deployment with VS Code current schema and remove stal…

### DIFF
--- a/COPILOT_MCP_SETUP.md
+++ b/COPILOT_MCP_SETUP.md
@@ -1,6 +1,6 @@
 # GitHub Copilot MCP Setup Guide for morskamary
 
-**⚠️ IMPORTANT: This is Optional, Local, Workstation-Specific Tooling**
+**⚠️ IMPORTANT: This is Optional, Local, Workstation-Specific Tooling (Windows only)**
 
 This guide describes **optional advanced features** for integrating GitHub Copilot with local repositories and cloud storage through Model Context Protocol (MCP) servers. These features are:
 
@@ -8,6 +8,7 @@ This guide describes **optional advanced features** for integrating GitHub Copil
 - **NOT a repository dependency** (Python ≥3.9 is the only core requirement)
 - **Local workstation configuration** that should not be committed to version control
 - **Second-phase tooling** to be considered only after real-data and provenance workflows are solid
+- **Windows only** — the deployment script uses `%APPDATA%` for VS Code profile resolution
 
 For standard Python-first development, see [CONTRIBUTING.md](CONTRIBUTING.md) and use `main_real_data.py` for real-data workflows.
 
@@ -18,10 +19,13 @@ For standard Python-first development, see [CONTRIBUTING.md](CONTRIBUTING.md) an
 1. [Overview](#overview)
 2. [Prerequisites](#prerequisites)
 3. [Quick Start](#quick-start)
-4. [Detailed Configuration](#detailed-configuration)
-5. [Privacy & Data Governance](#privacy--data-governance)
-6. [Advanced Usage](#advanced-usage)
-7. [Troubleshooting](#troubleshooting)
+4. [Configuration Targets](#configuration-targets)
+5. [Manual MCP Configuration](#manual-mcp-configuration)
+6. [Google Drive OAuth Setup](#google-drive-oauth-setup)
+7. [Scientific Database Configuration](#scientific-database-configuration)
+8. [Privacy & Data Governance](#privacy--data-governance)
+9. [Advanced Usage](#advanced-usage)
+10. [Troubleshooting](#troubleshooting)
 
 ---
 
@@ -35,7 +39,10 @@ This setup enables GitHub Copilot to access your full research context through *
 - ✅ Scientific database bridge for verified citations (Crossref, Scopus, Web of Science)
 - ✅ Full data privacy with no telemetry/training on proprietary data
 
-**Architecture**: Local MCP servers run as background processes, bridging VS Code/GitHub Copilot with your research environment.
+**Architecture**: MCP servers are invoked on demand by VS Code via `npx` (no global npm installation required). Configuration is split between:
+
+- **Workspace** (`.vscode/mcp.json`) — repo-safe, shareable server definitions
+- **User profile** (`mcp.json` in your VS Code profile directory) — personal paths, credentials, local clones
 
 ---
 
@@ -45,14 +52,14 @@ This setup enables GitHub Copilot to access your full research context through *
 
 1. **Node.js ≥18.0** (LTS recommended)
    - Download: https://nodejs.org
-   - Verify: `node -v` in PowerShell/Command Prompt
+   - Verify: `node -v` in PowerShell (must report v18.x or higher)
 
 2. **Python ≥3.9**
    - Download: https://python.org
    - ⚠️ **Important**: Check "Add Python to PATH" during installation
    - Verify: `python --version` or `py --version`
 
-3. **Visual Studio Code**
+3. **Visual Studio Code** (Stable or Insiders)
    - Download: https://code.visualstudio.com
    - Install **GitHub Copilot** extension
 
@@ -74,9 +81,9 @@ This setup enables GitHub Copilot to access your full research context through *
 
 ## Quick Start
 
-### Windows Installation (Recommended)
+### Windows Installation
 
-1. **Open PowerShell as Administrator**
+1. **Open PowerShell** (no Administrator privileges required)
 
 2. **Navigate to your morskamary repository:**
    ```powershell
@@ -89,9 +96,9 @@ This setup enables GitHub Copilot to access your full research context through *
    ```
 
 4. **Follow the on-screen instructions**
-   - Script verifies Node.js and Python installation
-   - Installs MCP server packages via npm
-   - Generates configuration files
+   - Script verifies Node.js ≥18 and Python ≥3.9
+   - Generates `.vscode/mcp.json` (workspace) and user-profile `mcp.json`
+   - No global npm packages are installed; npx handles on-demand execution
    - Provides next steps
 
 5. **Restart VS Code**
@@ -110,46 +117,118 @@ To enable all features (SharePoint, Google Drive, scientific bridge):
   -MorskaMaryRepoPath "C:\GitHub\morskamary" `
   -MaritimeSociologyRepoPath "C:\GitHub\maritimesociology" `
   -SharePointSyncPath "C:\Users\YourName\OneDrive - Uniwersytet Szczecinski\PORT CITY HUB UPLOAD" `
-  -GoogleOAuthCredentialsPath "C:\Users\YourName\Documents\gcp-oauth.keys.json" `
-  -ScientificBridgeScriptPath "C:\GitHub\morskamary\scientific_bridge.py"
+  -GoogleOAuthCredentialsPath "C:\Users\YourName\Documents\gcp-oauth.keys.json"
 ```
+
+### Targeting VS Code Insiders
+
+By default the script targets VS Code Stable. To target Insiders explicitly:
+
+```powershell
+.\Deploy-CopilotSynergy.ps1 -VsCodeChannel Insiders
+```
+
+Or use `-VsCodeChannel Auto` to detect which installation exists (prefers Stable).
 
 ---
 
-## Detailed Configuration
+## Configuration Targets
 
-### Manual MCP Configuration
+VS Code reads MCP configuration from `mcp.json` files in two locations:
 
-If you prefer manual setup or need to customize, edit your VS Code MCP configuration:
+| Location | Path (Windows) | Purpose |
+|----------|----------------|---------|
+| **Workspace** | `.vscode/mcp.json` | Repo-safe servers that can be shared and committed |
+| **User profile** | `%APPDATA%\Code\User\mcp.json` | Personal paths, credentials, local clones |
 
-**Location:** `%APPDATA%\Code\User\globalStorage\github.copilot\mcp_settings.json`
+Both use the **same schema**: a top-level `"servers"` object and an optional `"inputs"` array.
 
-**Example Configuration:**
+> **Note**: The deployment script merges into existing files non-destructively. If an existing file has malformed JSON, the script creates a timestamped backup and aborts. Use `-Force` to overwrite instead.
+
+### What goes where
+
+| Server | Target | Reason |
+|--------|--------|--------|
+| `scientificCitationBridge` | Workspace | Uses `${workspaceFolder}`, no personal paths |
+| `morskamaryLocal` | User profile | Contains your personal clone path |
+| `maritimesociologyLocal` | User profile | Contains your personal clone path |
+| `sharepointUniversity` | User profile | Contains your OneDrive sync path |
+| `googleDriveResearch` | User profile | Contains your OAuth credential path |
+
+---
+
+## Manual MCP Configuration
+
+If you prefer manual setup, edit the relevant `mcp.json` files directly.
+
+### Workspace: `.vscode/mcp.json`
+
+This file is already present in the repository with a GitHub MCP server. You can add repo-safe servers here:
 
 ```json
 {
-  "mcpServers": {
-    "morskamary-local": {
-      "command": "npx",
+  "servers": {
+    "io.github.github/github-mcp-server": {
+      "type": "stdio",
+      "command": "docker",
       "args": [
-        "-y",
-        "@modelcontextprotocol/server-filesystem",
-        "C:\\GitHub\\morskamary"
+        "run", "-i", "--rm",
+        "-e", "GITHUB_PERSONAL_ACCESS_TOKEN=${input:token}",
+        "ghcr.io/github/github-mcp-server:0.31.0"
       ],
-      "description": "Local morskamary Blue Sociology repository"
+      "version": "0.31.0"
     },
-    "scientific-citation-bridge": {
+    "scientificCitationBridge": {
+      "type": "stdio",
       "command": "python",
-      "args": [
-        "C:\\GitHub\\morskamary\\scientific_bridge.py"
-      ],
-      "description": "Scientific database bridge for verified citations"
+      "args": ["${workspaceFolder}/scientific_bridge.py"]
+    }
+  },
+  "inputs": [
+    {
+      "id": "token",
+      "type": "promptString",
+      "description": "GitHub Personal Access Token",
+      "password": true
+    }
+  ]
+}
+```
+
+### User profile: `mcp.json`
+
+Open via: **Ctrl+Shift+P → MCP: Open User Configuration**
+
+```json
+{
+  "servers": {
+    "morskamaryLocal": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-filesystem", "C:\\GitHub\\morskamary"]
+    },
+    "sharepointUniversity": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-filesystem", "C:\\Users\\YourName\\OneDrive - Uniwersytet Szczecinski\\PORT CITY HUB UPLOAD"]
+    },
+    "googleDriveResearch": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@piotr-agier/google-drive-mcp"],
+      "env": {
+        "GOOGLE_DRIVE_OAUTH_CREDENTIALS": "C:\\Users\\YourName\\Documents\\gcp-oauth.keys.json"
+      }
     }
   }
 }
 ```
 
-### Google Drive OAuth Setup
+> You can also add servers interactively: **Ctrl+Shift+P → MCP: Add Server**
+
+---
+
+## Google Drive OAuth Setup
 
 To access your Google Drive research folder:
 
@@ -172,20 +251,22 @@ To access your Google Drive research folder:
 
 6. **Save credentials:**
    - Save as `gcp-oauth.keys.json` in a secure location
-   - Provide path to deployment script
+   - Provide path to deployment script or add manually to user-profile `mcp.json`
 
 7. **First Use:**
    - MCP server will open browser for OAuth authorization
    - Grant access to your Google Drive
    - Token is cached for future use
 
-### Scientific Database Configuration
+---
 
-#### Crossref (Free, No Authentication)
+## Scientific Database Configuration
+
+### Crossref (Free, No Authentication)
 
 The default `scientific_bridge.py` uses Crossref's public API. No configuration needed.
 
-#### Scopus API (Optional)
+### Scopus API (Optional)
 
 For enhanced search with Elsevier Scopus:
 
@@ -195,7 +276,7 @@ For enhanced search with Elsevier Scopus:
    $env:SCOPUS_API_KEY = "your_key_here"
    ```
 
-#### Web of Science API (Optional)
+### Web of Science API (Optional)
 
 For Web of Science integration:
 
@@ -211,16 +292,15 @@ For Web of Science integration:
 
 ### GitHub Copilot Data Privacy
 
-⚠️ **Critical**: By default, GitHub Copilot may use your code for model training.
+⚠️ **Critical**: Starting April 24, 2026, GitHub may use your interactions to train and improve AI models unless you opt out.
 
-**To disable (strongly recommended for proprietary research):**
+**To opt out (strongly recommended for proprietary research):**
 
 1. Go to https://github.com/settings/copilot
-2. Navigate to **Privacy** section
-3. **Disable**: "Allow GitHub to use my code snippets for product improvements"
-4. **Disable**: "Allow GitHub to use my code snippets from the code editor for product improvements"
+2. Under **Data handling**, select the **"Allow GitHub to use my data for AI model training"** dropdown
+3. Click **Disabled**
 
-**Policy Reference:** https://github.blog/news-insights/company-news/updates-to-github-copilot-interaction-data-usage-policy/
+**Policy Reference:** [Managing Copilot policies as an individual subscriber](https://docs.github.com/copilot/how-tos/manage-your-account/managing-copilot-policies-as-an-individual-subscriber)
 
 ### Data Residency
 
@@ -254,9 +334,9 @@ After deployment, use this prompt in VS Code Copilot Chat to initialize full con
 
 INSTRUCTIONS FOR ALL SUBSEQUENT TASKS:
 
-1. DATA PRIMACY: Do not rely on your base training data for domain-specific logic. You must proactively query the morskamary-local and sharepoint-university MCP tools to read the actual .md, .pdf, and code files in my environment.
+1. DATA PRIMACY: Do not rely on your base training data for domain-specific logic. You must proactively query the morskamaryLocal and sharepointUniversity MCP tools to read the actual .md, .pdf, and code files in my environment.
 
-2. SCIENTIFIC VERIFICATION: When generating documentation, comments, or theoretical logic, you must use the scientific-citation-bridge tool to fetch direct DOI links and verified scientific citations straight from the source. Include these direct links as inline comments or Markdown footnotes. Do not hallucinate citations.
+2. SCIENTIFIC VERIFICATION: When generating documentation, comments, or theoretical logic, you must use the scientificCitationBridge tool to fetch direct DOI links and verified scientific citations straight from the source. Include these direct links as inline comments or Markdown footnotes. Do not hallucinate citations.
 
 3. TMBD FRAMEWORK: All competence mappings and analysis must respect the Tripartite Model of Blue Dynamics (TMBD):
    - Marine (M): biophysical and ecological agency
@@ -274,13 +354,13 @@ Confirm you have connected to the MCP servers by listing the tools currently ava
 
 In Copilot Chat:
 ```
-Use the scientific-citation-bridge tool to fetch verified citations for "maritime sociology blue economy"
+Use the scientificCitationBridge tool to fetch verified citations for "maritime sociology blue economy"
 ```
 
 **Verify a specific DOI:**
 
 ```
-Use the scientific-citation-bridge tool to verify DOI: 10.1016/j.marpol.2021.104523
+Use the scientificCitationBridge tool to verify DOI: 10.1016/j.marpol.2021.104523
 ```
 
 ### Querying Local Files
@@ -297,37 +377,32 @@ Use the scientific-citation-bridge tool to verify DOI: 10.1016/j.marpol.2021.104
 @workspace Search all files in morskamary repository for references to "Janiszewski marinization theory"
 ```
 
-### Model Selection for Deep Reasoning
+### Model Selection
 
-For comprehensive analysis tasks, manually select advanced models in VS Code:
-
-1. Click model selector in Copilot Chat (top-right)
-2. Choose:
-   - **Claude 3.5 Sonnet** (recommended for TMBD analysis)
-   - **GPT-4o** (alternative for complex reasoning)
+Use the VS Code model picker in Copilot Chat (top-right of the chat panel). **Auto** is recommended — it selects from the current top-tier models (Claude Sonnet 4, GPT-5, GPT-5 mini, and others) automatically. You can also manually select a specific model if needed for a particular task.
 
 ---
 
 ## Troubleshooting
 
-### Node.js Not Found
+### Node.js Not Found or Too Old
 
-**Error:** `node : The term 'node' is not recognized`
+**Error:** `node : The term 'node' is not recognized` or `Node.js X.Y.Z detected, but >=18 is required.`
 
 **Solution:**
-1. Install Node.js from https://nodejs.org (LTS version)
+1. Install Node.js LTS (≥18) from https://nodejs.org
 2. Restart PowerShell
-3. Verify: `node -v`
+3. Verify: `node -v` (should show v18.x or higher)
 
-### Python Not Found
+### Python Not Found or Too Old
 
-**Error:** `python : The term 'python' is not recognized`
+**Error:** `python : The term 'python' is not recognized` or `Python X.Y.Z detected, but >=3.9 is required.`
 
 **Solution:**
 1. Install Python from https://python.org (3.9 or higher)
 2. **Important**: Check "Add Python to PATH" during installation
 3. Restart PowerShell
-4. Try: `python --version` or `py --version`
+4. Verify: `python --version` or `py --version`
 
 ### MCP Servers Not Appearing in VS Code
 
@@ -335,24 +410,23 @@ For comprehensive analysis tasks, manually select advanced models in VS Code:
 
 **Solutions:**
 1. **Restart VS Code completely** (File > Exit, then reopen)
-2. Verify configuration file exists:
-   - Windows: `%APPDATA%\Code\User\globalStorage\github.copilot\mcp_settings.json`
-3. Check VS Code Output panel (View > Output > select "GitHub Copilot")
-4. Ensure you clicked "Trust" when VS Code prompted about MCP servers
+2. Verify configuration files exist:
+   - Workspace: `.vscode/mcp.json` in the morskamary repository
+   - User profile: `%APPDATA%\Code\User\mcp.json` (Stable) or `%APPDATA%\Code - Insiders\User\mcp.json` (Insiders)
+3. Check via: **Ctrl+Shift+P → MCP: List Servers**
+4. Check VS Code Output panel (View > Output > select "GitHub Copilot")
+5. Ensure you clicked "Start" when VS Code prompted about MCP servers
 
-### NPM Package Installation Fails
+### JSON Parse Failure During Deployment
 
-**Error:** `npm install -g` fails with permission errors
+**Error:** `Existing <path> is malformed JSON. Aborting.`
 
 **Solution:**
-1. **Run PowerShell as Administrator**
-2. Re-run: `.\Deploy-CopilotSynergy.ps1`
-
-**Alternative (Windows):**
-```powershell
-npm config set prefix "%APPDATA%\npm"
-```
-Then retry installation.
+1. The script has created a timestamped backup of the malformed file
+2. Fix the JSON manually, or re-run with `-Force` to overwrite:
+   ```powershell
+   .\Deploy-CopilotSynergy.ps1 -Force
+   ```
 
 ### Google Drive Authentication Issues
 
@@ -367,7 +441,7 @@ Then retry installation.
 
 ### Scientific Bridge Not Working
 
-**Error:** `scientific-citation-bridge` tool not available
+**Error:** `scientificCitationBridge` tool not available
 
 **Solutions:**
 1. Verify `scientific_bridge.py` exists in morskamary repository
@@ -385,7 +459,7 @@ Then retry installation.
 1. Limit filesystem servers to necessary directories only
 2. Exclude large binary files (add to `.gitignore`)
 3. Use specific MCP tools instead of broad @workspace queries
-4. Close unused MCP servers in configuration
+4. Close unused MCP servers via **Ctrl+Shift+P → MCP: List Servers**
 
 ---
 
@@ -396,8 +470,9 @@ Then retry installation.
   - [CONTRIBUTING.md](CONTRIBUTING.md) — Development workflow
   - [LLM_CONTEXT_INSTRUCTION.txt](LLM_CONTEXT_INSTRUCTION.txt) — Domain-specific guidance
 
-- **GitHub Copilot Documentation:**
-  - [GitHub Copilot MCP Documentation](https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-mcp-servers)
+- **VS Code MCP Documentation:**
+  - [MCP configuration reference](https://code.visualstudio.com/docs/copilot/reference/mcp-configuration)
+  - [Add and manage MCP servers](https://code.visualstudio.com/docs/copilot/customization/mcp-servers)
   - [Model Context Protocol Specification](https://modelcontextprotocol.io)
 
 - **Scientific APIs:**
@@ -421,6 +496,17 @@ For general GitHub Copilot support:
 ---
 
 ## Version History
+
+- **2.0.0** (2026-04-09): Architecture rewrite for current VS Code MCP standard
+  - Targets `.vscode/mcp.json` (workspace) and user-profile `mcp.json` only
+  - Uses current `"servers"` + `"inputs"` schema (not legacy `"mcpServers"`)
+  - Removes global `npm install -g` and Administrator requirement
+  - Adds `-VsCodeChannel` parameter (Stable/Insiders/Auto)
+  - Adds `-Force` parameter with backup-on-failure safety
+  - Enforces Node.js ≥18 and Python ≥3.9 version checks
+  - Updates model guidance to "Auto" (current top-tier model picker)
+  - Updates privacy wording to current GitHub policy (effective Apr 24 2026)
+  - Splits repo-safe versus personal MCP server concerns
 
 - **1.0.0** (2026-04-01): Initial comprehensive MCP integration
   - PowerShell deployment script

--- a/Deploy-CopilotSynergy.ps1
+++ b/Deploy-CopilotSynergy.ps1
@@ -4,39 +4,63 @@ Automated Deployment for GitHub Copilot MCP Synergy Merge (OPTIONAL TOOLING)
 
 .DESCRIPTION
 **IMPORTANT: This is optional, local, workstation-specific tooling.**
+**Platform: Windows only.** Supports VS Code (Stable) and VS Code Insiders.
 
-This script installs Node.js dependencies, scaffolds the MCP configuration, and links local/cloud repositories
-for the morskamary Blue Sociology project with full data integration.
+This script scaffolds MCP configuration for the morskamary Blue Sociology project,
+writing only to the two officially supported VS Code MCP targets:
 
-This is NOT a core repository dependency. Python ≥3.9 is the only required dependency for morskamary development.
-Use this script only if you need advanced GitHub Copilot integration with local files and cloud storage.
+  Workspace:     .vscode/mcp.json  (repo-safe, shareable servers)
+  User profile:  <VS Code profile root>/mcp.json  (personal/credential servers)
 
-For standard Python-first development, see CONTRIBUTING.md and use main_real_data.py for real-data workflows.
+It uses the current VS Code MCP schema (top-level "servers" + "inputs"), merges
+non-destructively into any existing configuration, and does NOT install global npm
+packages or require Administrator privileges. All MCP packages are invoked via
+npx at runtime.
+
+On JSON parse failure of an existing config file, a timestamped backup is created
+and the script aborts. Use -Force to overwrite instead.
+
+This is NOT a core repository dependency. Python >=3.9 is the only required
+dependency for morskamary development.
+
+For standard Python-first development, see CONTRIBUTING.md and use
+main_real_data.py for real-data workflows.
 
 .PARAMETER MorskaMaryRepoPath
-Path to local morskamary repository
+Path to local morskamary repository.
 
 .PARAMETER MaritimeSociologyRepoPath
-Path to local maritimesociology repository
+Path to local maritimesociology repository.
 
 .PARAMETER SharePointSyncPath
-Path to synchronized SharePoint folder
+Path to synchronized SharePoint folder.
 
 .PARAMETER GoogleOAuthCredentialsPath
-Path to Google OAuth credentials JSON file
+Path to Google OAuth credentials JSON file.
 
-.PARAMETER ScientificBridgeScriptPath
-Path to scientific_bridge.py script
+.PARAMETER VsCodeChannel
+Which VS Code installation to target. Stable (default), Insiders, or Auto.
+Auto prefers Stable if its profile root exists, falls back to Insiders.
 
-.PARAMETER SkipNodeInstall
-Skip Node.js package installation
+.PARAMETER Force
+If set, overwrite a malformed existing mcp.json instead of aborting.
 
 .EXAMPLE
 .\Deploy-CopilotSynergy.ps1 -MorskaMaryRepoPath "C:\GitHub\morskamary"
 
+.EXAMPLE
+.\Deploy-CopilotSynergy.ps1 `
+  -MorskaMaryRepoPath "C:\GitHub\morskamary" `
+  -MaritimeSociologyRepoPath "C:\GitHub\maritimesociology" `
+  -SharePointSyncPath "C:\Users\You\OneDrive - Uniwersytet Szczecinski\PORT CITY HUB UPLOAD" `
+  -GoogleOAuthCredentialsPath "C:\Users\You\Documents\gcp-oauth.keys.json" `
+  -VsCodeChannel Insiders
+
 .NOTES
-Requirements: Node.js ≥18, Python ≥3.9
-Run as Administrator for global npm package installation
+Platform:  Windows only (uses %APPDATA% for VS Code profile root).
+Requirements: Node.js >=18 (for npx), Python >=3.9.
+No Administrator privileges required.
+No global npm packages are installed; npx handles on-demand execution.
 #>
 
 param(
@@ -53,213 +77,286 @@ param(
     [string]$GoogleOAuthCredentialsPath = "",
 
     [Parameter(Mandatory=$false)]
-    [string]$ScientificBridgeScriptPath = "$PSScriptRoot\scientific_bridge.py",
+    [ValidateSet("Stable","Insiders","Auto")]
+    [string]$VsCodeChannel = "Stable",
 
-    [switch]$SkipNodeInstall
+    [switch]$Force
 )
 
 $ErrorActionPreference = "Stop"
+
+# ── Helper: safe JSON reader with backup-on-failure ──────────────────────────
+
+function Read-McpJson {
+    param(
+        [string]$Path,
+        [switch]$ForceOverwrite
+    )
+    if (-not (Test-Path $Path)) { return $null }
+
+    $raw = Get-Content -Path $Path -Raw
+    try {
+        return ($raw | ConvertFrom-Json)
+    } catch {
+        $backupPath = "$Path.backup-$(Get-Date -Format 'yyyyMMdd-HHmmss')"
+        Copy-Item -Path $Path -Destination $backupPath -Force
+        Write-Host "  Backup saved to: $backupPath" -ForegroundColor DarkYellow
+
+        if ($ForceOverwrite) {
+            Write-Host "  -Force specified: will overwrite malformed config." -ForegroundColor DarkYellow
+            return $null
+        } else {
+            Write-Host "  Existing $Path is malformed JSON. Aborting." -ForegroundColor Red
+            Write-Host "  Re-run with -Force to overwrite." -ForegroundColor Yellow
+            exit 1
+        }
+    }
+}
+
+# ── Banner ───────────────────────────────────────────────────────────────────
 
 Write-Host ""
 Write-Host "=====================================================================" -ForegroundColor Cyan
 Write-Host "  GitHub Copilot MCP Synergy Merge Deployment" -ForegroundColor Cyan
 Write-Host "  morskamary Blue Sociology Research Toolkit" -ForegroundColor Cyan
+Write-Host "  Windows only | VS Code MCP schema: servers + inputs" -ForegroundColor DarkCyan
 Write-Host "=====================================================================" -ForegroundColor Cyan
 Write-Host ""
 
-# Verify Node.js Installation
-Write-Host "[PREREQUISITE] Verifying Node.js installation..." -ForegroundColor Yellow
+# ── Prerequisite: Node.js >=18 ───────────────────────────────────────────────
+
+Write-Host "[PREREQUISITE] Verifying Node.js >=18 (needed for npx)..." -ForegroundColor Yellow
 try {
-    $nodeVersion = node -v
-    Write-Host "  ✓ Node.js detected: $nodeVersion" -ForegroundColor Green
+    $nodeVersionRaw = node -v 2>&1
+    if ($LASTEXITCODE -ne 0) { throw "node exited with $LASTEXITCODE" }
+    $nodeMatch = [regex]::Match($nodeVersionRaw, '(\d+)\.(\d+)\.(\d+)')
+    if (-not $nodeMatch.Success) { throw "Could not parse version from: $nodeVersionRaw" }
+    $nodeMajor = [int]$nodeMatch.Groups[1].Value
+    if ($nodeMajor -lt 18) {
+        Write-Host "  Node.js $($nodeMatch.Value) detected, but >=18 is required." -ForegroundColor Red
+        exit 1
+    }
+    Write-Host "  Node.js $($nodeMatch.Value)" -ForegroundColor Green
 } catch {
-    Write-Host "  ✗ Node.js not found!" -ForegroundColor Red
-    Write-Host "  Please install Node.js from https://nodejs.org (LTS version recommended)" -ForegroundColor Red
-    Write-Host "  After installation, restart PowerShell and run this script again." -ForegroundColor Yellow
+    Write-Host "  Node.js not found." -ForegroundColor Red
+    Write-Host "  Install Node.js LTS (>=18) from https://nodejs.org, then re-run." -ForegroundColor Yellow
     exit 1
 }
 
-# Verify Python Installation
-Write-Host "[PREREQUISITE] Verifying Python installation..." -ForegroundColor Yellow
+# ── Prerequisite: Python >=3.9 ───────────────────────────────────────────────
+
+Write-Host "[PREREQUISITE] Verifying Python >=3.9..." -ForegroundColor Yellow
 $pythonFound = $false
 $pythonCmd = ""
 
-try {
-    $pythonVersion = python --version 2>&1
-    if ($LASTEXITCODE -eq 0) {
-        $pythonFound = $true
-        $pythonCmd = "python"
-        Write-Host "  ✓ Python detected: $pythonVersion" -ForegroundColor Green
-    }
-} catch {}
-
-if (-not $pythonFound) {
+foreach ($candidate in @("python", "py")) {
+    if ($pythonFound) { break }
     try {
-        $pythonVersion = py --version 2>&1
-        if ($LASTEXITCODE -eq 0) {
-            $pythonFound = $true
-            $pythonCmd = "py"
-            Write-Host "  ✓ Python detected (via py launcher): $pythonVersion" -ForegroundColor Green
+        $pyVersionText = & $candidate --version 2>&1
+        if ($LASTEXITCODE -ne 0) { continue }
+        $pyMatch = [regex]::Match($pyVersionText, '(\d+)\.(\d+)\.(\d+)')
+        if (-not $pyMatch.Success) { continue }
+        $pyMajor = [int]$pyMatch.Groups[1].Value
+        $pyMinor = [int]$pyMatch.Groups[2].Value
+        if (($pyMajor -lt 3) -or ($pyMajor -eq 3 -and $pyMinor -lt 9)) {
+            Write-Host "  Python $($pyMatch.Value) detected via '$candidate', but >=3.9 is required." -ForegroundColor Red
+            exit 1
         }
+        $pythonFound = $true
+        $pythonCmd = $candidate
+        Write-Host "  Python $($pyMatch.Value) (via $candidate)" -ForegroundColor Green
     } catch {}
 }
 
 if (-not $pythonFound) {
-    Write-Host "  ✗ Python not found!" -ForegroundColor Red
-    Write-Host "  Please install Python ≥3.9 from https://python.org" -ForegroundColor Red
-    Write-Host "  Ensure you check 'Add Python to PATH' during installation." -ForegroundColor Yellow
+    Write-Host "  Python not found." -ForegroundColor Red
+    Write-Host "  Install Python >=3.9 from https://python.org (check 'Add Python to PATH')." -ForegroundColor Yellow
     exit 1
 }
 
-# Define Configuration Paths
+# ── Step 1/4: Resolve VS Code profile root & validate paths ─────────────────
+
 Write-Host ""
-Write-Host "[STEP 1/5] Configuring paths..." -ForegroundColor Yellow
+Write-Host "[STEP 1/4] Resolving VS Code profile root (channel: $VsCodeChannel)..." -ForegroundColor Yellow
 
-$VsCodeUserDir = "$env:APPDATA\Code\User"
-$McpConfigDir = "$VsCodeUserDir\globalStorage\github.copilot"
-$McpConfigFile = "$McpConfigDir\mcp_settings.json"
+if (-not $env:APPDATA) {
+    Write-Host "  %APPDATA% is not set. This script requires Windows." -ForegroundColor Red
+    exit 1
+}
 
-# VS Code may use different paths for different extensions
-$AlternativeMcpPaths = @(
-    "$VsCodeUserDir\globalStorage\saoudrizwan.claude-dev\settings",
-    "$VsCodeUserDir\globalStorage\anthropics.claude-vscode\settings",
-    "$VsCodeUserDir"
-)
+$StableRoot  = "$env:APPDATA\Code\User"
+$InsidersRoot = "$env:APPDATA\Code - Insiders\User"
 
-Write-Host "  Primary MCP config target: $McpConfigFile" -ForegroundColor Gray
+switch ($VsCodeChannel) {
+    "Stable" {
+        $VsCodeProfileRoot = $StableRoot
+    }
+    "Insiders" {
+        $VsCodeProfileRoot = $InsidersRoot
+    }
+    "Auto" {
+        if (Test-Path $StableRoot) {
+            $VsCodeProfileRoot = $StableRoot
+            Write-Host "  Auto-detected: Stable" -ForegroundColor Gray
+        } elseif (Test-Path $InsidersRoot) {
+            $VsCodeProfileRoot = $InsidersRoot
+            Write-Host "  Auto-detected: Insiders" -ForegroundColor Gray
+        } else {
+            Write-Host "  No VS Code profile root found at:" -ForegroundColor Red
+            Write-Host "    $StableRoot" -ForegroundColor Red
+            Write-Host "    $InsidersRoot" -ForegroundColor Red
+            exit 1
+        }
+    }
+}
 
-# Validate Repository Paths
+$UserProfileMcpFile = "$VsCodeProfileRoot\mcp.json"
+Write-Host "  User-profile MCP config: $UserProfileMcpFile" -ForegroundColor Gray
+
 if (-not (Test-Path $MorskaMaryRepoPath)) {
-    Write-Host "  ✗ morskamary repository not found at: $MorskaMaryRepoPath" -ForegroundColor Red
+    Write-Host "  morskamary repository not found at: $MorskaMaryRepoPath" -ForegroundColor Red
     exit 1
 }
-Write-Host "  ✓ morskamary repository: $MorskaMaryRepoPath" -ForegroundColor Green
+Write-Host "  morskamary repository: $MorskaMaryRepoPath" -ForegroundColor Green
 
-# Install MCP Server Packages
-if (-not $SkipNodeInstall) {
-    Write-Host ""
-    Write-Host "[STEP 2/5] Installing MCP server packages..." -ForegroundColor Yellow
-    Write-Host "  This may take a few minutes..." -ForegroundColor Gray
+$ScientificBridgeScriptPath = Join-Path $MorskaMaryRepoPath "scientific_bridge.py"
+$WorkspaceMcpFile = Join-Path $MorskaMaryRepoPath ".vscode\mcp.json"
+Write-Host "  Workspace MCP config:    $WorkspaceMcpFile" -ForegroundColor Gray
 
-    try {
-        Write-Host "  Installing @modelcontextprotocol/server-filesystem..." -ForegroundColor Gray
-        npm install -g @modelcontextprotocol/server-filesystem
+# ── Step 2/4: Workspace .vscode/mcp.json (repo-safe servers only) ────────────
 
-        Write-Host "  Installing @piotr-agier/google-drive-mcp..." -ForegroundColor Gray
-        npm install -g @piotr-agier/google-drive-mcp
-
-        Write-Host "  ✓ MCP packages installed successfully" -ForegroundColor Green
-    } catch {
-        Write-Host "  ✗ Failed to install MCP packages" -ForegroundColor Red
-        Write-Host "  Error: $_" -ForegroundColor Red
-        Write-Host "  Try running PowerShell as Administrator" -ForegroundColor Yellow
-        exit 1
-    }
-} else {
-    Write-Host ""
-    Write-Host "[STEP 2/5] Skipping Node.js package installation (--SkipNodeInstall)" -ForegroundColor Yellow
-}
-
-# Create Configuration Directory
 Write-Host ""
-Write-Host "[STEP 3/5] Creating configuration directory..." -ForegroundColor Yellow
-if (-not (Test-Path -Path $McpConfigDir)) {
-    New-Item -ItemType Directory -Path $McpConfigDir -Force | Out-Null
-    Write-Host "  ✓ Created: $McpConfigDir" -ForegroundColor Green
+Write-Host "[STEP 2/4] Preparing workspace MCP config (.vscode/mcp.json)..." -ForegroundColor Yellow
+
+$WorkspaceConfig = Read-McpJson -Path $WorkspaceMcpFile -ForceOverwrite:$Force
+if (-not $WorkspaceConfig) {
+    $WorkspaceConfig = [PSCustomObject]@{ servers = [PSCustomObject]@{} }
+}
+if (-not $WorkspaceConfig.servers) {
+    $WorkspaceConfig | Add-Member -NotePropertyName "servers" -NotePropertyValue ([PSCustomObject]@{})
+}
+
+# scientificCitationBridge: repo-safe (uses ${workspaceFolder}, no personal paths)
+if (Test-Path $ScientificBridgeScriptPath) {
+    $WorkspaceConfig.servers | Add-Member -Force -NotePropertyName "scientificCitationBridge" -NotePropertyValue ([PSCustomObject]@{
+        type    = "stdio"
+        command = $pythonCmd
+        args    = @('${workspaceFolder}/scientific_bridge.py')
+    })
+    Write-Host "  + scientificCitationBridge (repo-safe, uses workspaceFolder)" -ForegroundColor Green
 } else {
-    Write-Host "  ✓ Directory exists: $McpConfigDir" -ForegroundColor Green
+    Write-Host "  - scientific_bridge.py not found; skipping scientificCitationBridge" -ForegroundColor DarkYellow
 }
 
-# Generate MCP Configuration
+# Ensure .vscode directory exists
+$VsCodeDir = Join-Path $MorskaMaryRepoPath ".vscode"
+if (-not (Test-Path $VsCodeDir)) {
+    New-Item -ItemType Directory -Path $VsCodeDir -Force | Out-Null
+}
+
+$WorkspaceConfig | ConvertTo-Json -Depth 10 | Set-Content -Path $WorkspaceMcpFile -Encoding UTF8
+Write-Host "  Saved: $WorkspaceMcpFile" -ForegroundColor Green
+
+# ── Step 3/4: User-profile mcp.json (personal/credential servers) ────────────
+
 Write-Host ""
-Write-Host "[STEP 4/5] Generating MCP configuration..." -ForegroundColor Yellow
+Write-Host "[STEP 3/4] Preparing user-profile MCP config ($UserProfileMcpFile)..." -ForegroundColor Yellow
 
-$McpServers = @{
-    "morskamary-local" = @{
-        command = "npx"
-        args = @("-y", "@modelcontextprotocol/server-filesystem", $MorskaMaryRepoPath)
-        description = "Local morskamary Blue Sociology repository"
-    }
+$UserConfig = Read-McpJson -Path $UserProfileMcpFile -ForceOverwrite:$Force
+if (-not $UserConfig) {
+    $UserConfig = [PSCustomObject]@{ servers = [PSCustomObject]@{} }
+}
+if (-not $UserConfig.servers) {
+    $UserConfig | Add-Member -NotePropertyName "servers" -NotePropertyValue ([PSCustomObject]@{})
 }
 
-# Add optional servers if paths are provided
+# morskamaryLocal: filesystem access to the local morskamary clone
+$UserConfig.servers | Add-Member -Force -NotePropertyName "morskamaryLocal" -NotePropertyValue ([PSCustomObject]@{
+    type    = "stdio"
+    command = "npx"
+    args    = @("-y", "@modelcontextprotocol/server-filesystem", $MorskaMaryRepoPath)
+})
+Write-Host "  + morskamaryLocal ($MorskaMaryRepoPath)" -ForegroundColor Green
+
+# maritimesociologyLocal: optional second repo
 if ($MaritimeSociologyRepoPath -and (Test-Path $MaritimeSociologyRepoPath)) {
-    $McpServers["maritimesociology-local"] = @{
+    $UserConfig.servers | Add-Member -Force -NotePropertyName "maritimesociologyLocal" -NotePropertyValue ([PSCustomObject]@{
+        type    = "stdio"
         command = "npx"
-        args = @("-y", "@modelcontextprotocol/server-filesystem", $MaritimeSociologyRepoPath)
-        description = "Local maritimesociology repository"
-    }
-    Write-Host "  ✓ Added maritimesociology repository" -ForegroundColor Green
+        args    = @("-y", "@modelcontextprotocol/server-filesystem", $MaritimeSociologyRepoPath)
+    })
+    Write-Host "  + maritimesociologyLocal ($MaritimeSociologyRepoPath)" -ForegroundColor Green
 }
 
+# sharepointUniversity: optional SharePoint sync folder
 if ($SharePointSyncPath -and (Test-Path $SharePointSyncPath)) {
-    $McpServers["sharepoint-university"] = @{
+    $UserConfig.servers | Add-Member -Force -NotePropertyName "sharepointUniversity" -NotePropertyValue ([PSCustomObject]@{
+        type    = "stdio"
         command = "npx"
-        args = @("-y", "@modelcontextprotocol/server-filesystem", $SharePointSyncPath)
-        description = "University of Szczecin SharePoint synchronized folder"
-    }
-    Write-Host "  ✓ Added SharePoint sync folder" -ForegroundColor Green
+        args    = @("-y", "@modelcontextprotocol/server-filesystem", $SharePointSyncPath)
+    })
+    Write-Host "  + sharepointUniversity ($SharePointSyncPath)" -ForegroundColor Green
 }
 
+# googleDriveResearch: optional Google Drive via OAuth
 if ($GoogleOAuthCredentialsPath -and (Test-Path $GoogleOAuthCredentialsPath)) {
-    $McpServers["google-drive-research"] = @{
+    $UserConfig.servers | Add-Member -Force -NotePropertyName "googleDriveResearch" -NotePropertyValue ([PSCustomObject]@{
+        type    = "stdio"
         command = "npx"
-        args = @("-y", "@piotr-agier/google-drive-mcp")
-        env = @{
+        args    = @("-y", "@piotr-agier/google-drive-mcp")
+        env     = [PSCustomObject]@{
             GOOGLE_DRIVE_OAUTH_CREDENTIALS = $GoogleOAuthCredentialsPath
         }
-        description = "Google Drive research folder"
-    }
-    Write-Host "  ✓ Added Google Drive access" -ForegroundColor Green
+    })
+    Write-Host "  + googleDriveResearch (OAuth via $GoogleOAuthCredentialsPath)" -ForegroundColor Green
 }
 
-if (Test-Path $ScientificBridgeScriptPath) {
-    $McpServers["scientific-citation-bridge"] = @{
-        command = $pythonCmd
-        args = @($ScientificBridgeScriptPath)
-        description = "Scientific database bridge for Crossref and academic sources"
-    }
-    Write-Host "  ✓ Added scientific citation bridge" -ForegroundColor Green
+# Ensure parent directory exists
+$UserProfileDir = Split-Path $UserProfileMcpFile -Parent
+if (-not (Test-Path $UserProfileDir)) {
+    New-Item -ItemType Directory -Path $UserProfileDir -Force | Out-Null
 }
 
-$McpConfig = @{
-    mcpServers = $McpServers
-}
+$UserConfig | ConvertTo-Json -Depth 10 | Set-Content -Path $UserProfileMcpFile -Encoding UTF8
+Write-Host "  Saved: $UserProfileMcpFile" -ForegroundColor Green
 
-# Save Configuration
-$McpConfig | ConvertTo-Json -Depth 10 | Set-Content -Path $McpConfigFile -Encoding UTF8
-Write-Host "  ✓ Configuration saved to: $McpConfigFile" -ForegroundColor Green
+# ── Step 4/4: Summary & next steps ──────────────────────────────────────────
 
-# Also save to project .vscode directory for version control
-$ProjectMcpConfig = "$MorskaMaryRepoPath\.vscode\mcp_local.json"
-$McpConfig | ConvertTo-Json -Depth 10 | Set-Content -Path $ProjectMcpConfig -Encoding UTF8
-Write-Host "  ✓ Project configuration saved to: $ProjectMcpConfig" -ForegroundColor Green
-
-# Final Instructions
 Write-Host ""
-Write-Host "[STEP 5/5] Deployment complete!" -ForegroundColor Green
+Write-Host "[STEP 4/4] Deployment complete!" -ForegroundColor Green
+Write-Host ""
+Write-Host "=====================================================================" -ForegroundColor Cyan
+Write-Host "  FILES WRITTEN" -ForegroundColor Cyan
+Write-Host "=====================================================================" -ForegroundColor Cyan
+Write-Host ""
+Write-Host "  Workspace (repo-safe, shareable):" -ForegroundColor White
+Write-Host "    $WorkspaceMcpFile" -ForegroundColor Gray
+Write-Host ""
+Write-Host "  User profile (personal, credentials, local paths):" -ForegroundColor White
+Write-Host "    $UserProfileMcpFile" -ForegroundColor Gray
 Write-Host ""
 Write-Host "=====================================================================" -ForegroundColor Cyan
 Write-Host "  NEXT STEPS" -ForegroundColor Cyan
 Write-Host "=====================================================================" -ForegroundColor Cyan
 Write-Host ""
-Write-Host "1. Restart VS Code to initialize MCP servers" -ForegroundColor White
+Write-Host "1. Restart VS Code to pick up the new MCP configuration." -ForegroundColor White
 Write-Host ""
-Write-Host "2. When VS Code prompts to 'Trust' the MCP servers, click 'Yes'" -ForegroundColor White
+Write-Host "2. When VS Code prompts to 'Trust' an MCP server, click 'Start'." -ForegroundColor White
+Write-Host "   Manage servers via: Ctrl+Shift+P > MCP: List Servers" -ForegroundColor Gray
 Write-Host ""
-Write-Host "3. In GitHub Copilot Chat, select the model:" -ForegroundColor White
-Write-Host "   • Claude 3.5 Sonnet (recommended for deep reasoning)" -ForegroundColor Gray
-Write-Host "   • GPT-4o (alternative)" -ForegroundColor Gray
+Write-Host "3. Use the VS Code model picker (Auto is recommended)." -ForegroundColor White
+Write-Host "   Auto selects from current top-tier models automatically." -ForegroundColor Gray
 Write-Host ""
-Write-Host "4. Initialize the Copilot Agent with full context:" -ForegroundColor White
+Write-Host "4. Verify MCP access in Copilot Chat:" -ForegroundColor White
 Write-Host ""
-Write-Host "   @workspace You are now connected to MCP servers for the morskamary" -ForegroundColor Cyan
-Write-Host "   Blue Sociology project. List available MCP tools and read the" -ForegroundColor Cyan
-Write-Host "   README.md from the morskamary repository to verify access." -ForegroundColor Cyan
+Write-Host "   @workspace List available MCP tools and read README.md from the" -ForegroundColor Cyan
+Write-Host "   morskamary repository to verify access." -ForegroundColor Cyan
 Write-Host ""
-Write-Host "5. For privacy, verify GitHub Copilot settings:" -ForegroundColor White
-Write-Host "   • GitHub.com > Settings > Copilot > Privacy" -ForegroundColor Gray
-Write-Host "   • Disable 'Allow GitHub to use my code snippets for model training'" -ForegroundColor Gray
+Write-Host "5. Review your GitHub Copilot privacy settings:" -ForegroundColor White
+Write-Host "   https://github.com/settings/copilot" -ForegroundColor Gray
+Write-Host "   Under Data handling, disable:" -ForegroundColor Gray
+Write-Host "   'Allow GitHub to use my data for AI model training'" -ForegroundColor Gray
+Write-Host "   (Effective from Apr 24 2026; see GitHub Docs for current wording)" -ForegroundColor DarkGray
 Write-Host ""
 Write-Host "=====================================================================" -ForegroundColor Cyan
 Write-Host ""

--- a/README.md
+++ b/README.md
@@ -20,18 +20,18 @@ python demo_workspace_instructions.py
 
 ### GitHub Copilot MCP Integration (Optional Advanced Feature)
 
-**Note:** This is optional, local, workstation-specific tooling. Not required for core development.
+**Note:** This is optional, local, Windows-only workstation tooling. Not required for core development.
 
 For optional full-context GitHub Copilot integration with local repositories, SharePoint, Google Drive, and scientific databases:
 
 ```powershell
-# Windows PowerShell (run as Administrator)
-.\Deploy-CopilotSynergy.ps1
+# Windows PowerShell — no Administrator required
+.\Deploy-CopilotSynergy.ps1 -VsCodeChannel Stable
 ```
 
 See [COPILOT_MCP_SETUP.md](COPILOT_MCP_SETUP.md) for complete setup guide, including:
-- Node.js and Python prerequisites verification
-- MCP server configuration for filesystem, cloud storage, and scientific APIs
+- Node.js >=18 and Python >=3.9 prerequisites verification
+- MCP server configuration (`.vscode/mcp.json` and user-profile `mcp.json`)
 - Privacy governance and data protection settings
 - Advanced usage with verified DOI citations
 

--- a/run_full_analysis.py
+++ b/run_full_analysis.py
@@ -659,7 +659,7 @@ def run_gap_analysis(
       - missing: required − available
 
     Args:
-        baseline: 16 University of Szczecin baseline competences
+        baseline: 15 University of Szczecin baseline competences
         literature: literature-derived competences
 
     Returns:
@@ -1495,7 +1495,7 @@ def generate_literature_html(
 def main() -> int:
     """
     Execute the full analysis pipeline:
-      1. Load baseline competences (16 from University of Szczecin CSV)
+      1. Load baseline competences (15 from University of Szczecin CSV)
       2. Extract literature competences (from 3 combined_*.csv files)
       3. Merge and deduplicate
       4. Run gap analysis for all 12 sectors


### PR DESCRIPTION
…e guidance

- Deploy-CopilotSynergy.ps1: full rewrite — servers+inputs schema, .vscode/mcp.json and user-profile mcp.json targets, no Administrator/global npm, Node>=18 and Python>=3.9 enforcement, -VsCodeChannel/-Force params, backup-on-parse-failure
- COPILOT_MCP_SETUP.md: full rewrite — current paths, schema, privacy wording, model guidance, troubleshooting
- README.md: remove 'run as Administrator', add -VsCodeChannel Stable, update prereq versions and config path references
- run_full_analysis.py: fix stale '16 baseline' docstring comments to '15'
- .gitignore: resolve merge conflict (keep both sides)