### PR TITLE
Add literature extraction and TMBD axis classifier; pin NLP/ML deps

### DIFF
--- a/docs/BASELINE_VALIDATION.md
+++ b/docs/BASELINE_VALIDATION.md
@@ -1,0 +1,26 @@
+# Baseline Validation: TMBD Axis Classification
+
+## Cel
+Zweryfikować baseline dla klasyfikacji osi TMBD (`MARINE`, `MARITIME`, `OCEANIC`) przed dalszym strojenie modelu.
+
+## Konfiguracja eksperymentu
+- **Zbiór danych**: kompetencje z `data/derived/Blue Social Competences Univ Szczecin - Overall Blue Competences Dimension.csv`.
+- **Liczba próbek**: 39.
+- **Etykiety (ground truth)**: mapowanie `ID` -> oś przez regułę:
+  - `A -> OCEANIC`
+  - `B -> MARITIME`
+  - `C -> MARINE`
+  - `D -> MARITIME`
+- **Model baseline**: deterministyczny klasyfikator regułowy (`src/axis_classifier.py`) delegujący do `map_dimension_to_axis` przy dostępnej informacji o wymiarze.
+- **Walidacja**: 5-fold CV, `shuffle=True`, `random_state=42`.
+- **Metryka główna**: accuracy.
+
+## Wyniki baseline
+- **CV accuracy (mean)**: **1.00**
+- **CV accuracy (std)**: **0.00**
+
+## Interpretacja
+Wynik 1.00 wynika z faktu, że baseline wykorzystuje tę samą regułę mapującą, która służy do budowy etykiet referencyjnych. Jest to punkt odniesienia dla kolejnych eksperymentów opartych o klasyfikację z treści abstraktów (bez bezpośredniej informacji o wymiarze).
+
+## Następny krok
+Przygotować alternatywny benchmark tekstowy (np. TF-IDF + Logistic Regression), gdzie wejściem jest opis kompetencji, a nie kod wymiaru.

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,7 @@ pytest>=7.0
 # flake8>=6.0
 # mypy>=1.0
  
+# NLP and baseline ML stack for literature extraction/classification
+spacy==3.7.5
+sentence-transformers==2.7.0
+scikit-learn==1.5.2

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -7,6 +7,8 @@ based on Blue Sociology principles and the Tripartite Model of Blue Dynamics (TM
 Core modules:
 - core: Base utilities and data structures
 - competence_mapper: Competence mapping and analysis
+- literature_extraction: Abstract parsing and competence phrase extraction
+- axis_classifier: TMBD axis classification utilities
 """
 
 __version__ = "0.2.0"

--- a/src/axis_classifier.py
+++ b/src/axis_classifier.py
@@ -1,0 +1,34 @@
+"""Production module for TMBD axis classification."""
+
+from __future__ import annotations
+
+import re
+
+from src.core import BlueDynamicsAxis
+from load_real_competences import map_dimension_to_axis
+
+
+class AxisClassifier:
+    """Classifier facade for assigning TMBD axis labels."""
+
+    KEYWORD_AXIS_MAP = {
+        BlueDynamicsAxis.MARINE: ("ecosystem", "biodiversity", "habitat", "species"),
+        BlueDynamicsAxis.MARITIME: ("port", "shipping", "infrastructure", "logistics"),
+        BlueDynamicsAxis.OCEANIC: ("governance", "policy", "cooperation", "justice"),
+    }
+
+    def classify_axis(self, text: str, dimension: str | None = None) -> BlueDynamicsAxis:
+        """Classify axis using dimension-first logic and a text fallback."""
+        if dimension:
+            return map_dimension_to_axis(dimension)
+
+        if not text or not text.strip():
+            return BlueDynamicsAxis.OCEANIC
+
+        normalized = re.sub(r"\s+", " ", text.lower())
+
+        for axis, keywords in self.KEYWORD_AXIS_MAP.items():
+            if any(keyword in normalized for keyword in keywords):
+                return axis
+
+        return BlueDynamicsAxis.OCEANIC

--- a/src/literature_extraction.py
+++ b/src/literature_extraction.py
@@ -40,7 +40,11 @@ class LiteratureExtractor:
             return []
 
         normalized = re.sub(r"\s+", " ", text.strip())
-        return [chunk.strip() for chunk in re.split(r"(?<=[.!?])\s+", normalized) if chunk.strip()]
+        return [
+            chunk.strip()
+            for chunk in re.split(r"(?<=[.!?])\s+", normalized)
+            if chunk.strip()
+        ]
 
     def detect_competence_phrases(self, text: str) -> List[ExtractionRecord]:
         """Detect competence phrases and return records with confidence metadata."""

--- a/src/literature_extraction.py
+++ b/src/literature_extraction.py
@@ -1,0 +1,72 @@
+"""Utilities for extracting competence-related signals from literature abstracts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import re
+from typing import Iterable, List
+
+
+@dataclass(frozen=True)
+class ExtractionRecord:
+    """Structured extraction output for a single competence phrase hit."""
+
+    abstract_excerpt: str
+    extraction_method: str
+    confidence_score: float
+
+
+class LiteratureExtractor:
+    """Extract competence-focused snippets from scientific abstract text."""
+
+    DEFAULT_COMPETENCE_PATTERNS = (
+        r"\bcompetenc(?:e|ies)\b",
+        r"\bskill(?:s)?\b",
+        r"\bliteracy\b",
+        r"\bcapacity\s+building\b",
+        r"\bgovernance\b",
+    )
+
+    def __init__(self, competence_patterns: Iterable[str] | None = None) -> None:
+        patterns = tuple(competence_patterns or self.DEFAULT_COMPETENCE_PATTERNS)
+        self._pattern_sources = patterns
+        self._compiled_patterns = tuple(
+            re.compile(pattern, flags=re.IGNORECASE) for pattern in patterns
+        )
+
+    def parse_abstracts(self, text: str) -> List[str]:
+        """Parse one raw text blob into cleaned abstract fragments/sentences."""
+        if not text or not text.strip():
+            return []
+
+        normalized = re.sub(r"\s+", " ", text.strip())
+        return [chunk.strip() for chunk in re.split(r"(?<=[.!?])\s+", normalized) if chunk.strip()]
+
+    def detect_competence_phrases(self, text: str) -> List[ExtractionRecord]:
+        """Detect competence phrases and return records with confidence metadata."""
+        sentences = self.parse_abstracts(text)
+        if not sentences:
+            return []
+
+        records: List[ExtractionRecord] = []
+        for sentence in sentences:
+            for pattern_source, pattern in zip(
+                self._pattern_sources, self._compiled_patterns
+            ):
+                if pattern.search(sentence):
+                    records.append(
+                        ExtractionRecord(
+                            abstract_excerpt=sentence,
+                            extraction_method=f"regex:{pattern_source}",
+                            confidence_score=0.75,
+                        )
+                    )
+                    break
+
+        return records
+
+
+def extract_from_abstracts(text: str) -> List[dict]:
+    """Convenience API returning serializable extraction records."""
+    extractor = LiteratureExtractor()
+    return [record.__dict__ for record in extractor.detect_competence_phrases(text)]

--- a/tests/test_literature_extraction.py
+++ b/tests/test_literature_extraction.py
@@ -1,0 +1,29 @@
+"""Tests for literature abstraction extraction API."""
+
+from src.literature_extraction import LiteratureExtractor, extract_from_abstracts
+
+
+def test_extracts_excerpt_with_competence_phrase() -> None:
+    text = "This abstract discusses blue economy competence development in ports."
+
+    records = extract_from_abstracts(text)
+
+    assert len(records) == 1
+    assert "competence" in records[0]["abstract_excerpt"].lower()
+
+
+def test_records_include_required_fields() -> None:
+    text = "Capacity building and maritime skills are central to adaptation."
+
+    records = extract_from_abstracts(text)
+
+    assert records
+    required_fields = {"abstract_excerpt", "extraction_method", "confidence_score"}
+    assert required_fields.issubset(records[0].keys())
+
+
+def test_empty_input_returns_no_records() -> None:
+    extractor = LiteratureExtractor()
+
+    assert extractor.detect_competence_phrases("") == []
+    assert extractor.detect_competence_phrases("   ") == []


### PR DESCRIPTION
### Motivation
- Zapewnienie prostego, produkcyjnego API do parsowania abstraktów i wykrywania fraz związanych z kompetencjami jako podstawa dalszych ekstrakcji i klasyfikacji.
- Wprowadzenie modułu klasyfikacji osi TMBD w formie fasady produkcyjnej, która może delegować do istniejącej reguły wymiar→oś i posłużyć jako baseline.
- Zadbanie o powtarzalność eksperymentów NLP/ML przez przypięcie kompatybilnych wersji bibliotek używanych w przyszłych benchmarkach.

### Description
- Zaktualizowano `requirements.txt` o przypięte wersje: `spacy==3.7.5`, `sentence-transformers==2.7.0`, `scikit-learn==1.5.2`.
- Dodano `src/literature_extraction.py` zawierający `ExtractionRecord` oraz klasę `LiteratureExtractor` z metodami `parse_abstracts`, `detect_competence_phrases` i pomocniczą funkcją `extract_from_abstracts` zwracającą serializowalne rekordy z polami `abstract_excerpt`, `extraction_method`, `confidence_score`.
- Dodano `src/axis_classifier.py` jako moduł fasadowy `AxisClassifier` z logiką `dimension`-first (delegacja do `map_dimension_to_axis`) oraz fallbackem opartym na słownikach słów kluczowych w tekście.
- Dodano testy `tests/test_literature_extraction.py`, dokument baseline `docs/BASELINE_VALIDATION.md` oraz uzupełniono `src/__init__.py` o odniesienia do nowych modułów.

### Testing
- Uruchomiono `pytest tests/test_literature_extraction.py` i wszystkie testy przeszły pomyślnie (`3 passed`).
- Wykonano lekki smoke-check importu i użycia `AxisClassifier` (przykładowe asercje na `classify_axis`) i zakończył się sukcesem.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e60e7c8010832e85bd8b0f33d71b2b)