### PR TITLE
Mark main demo test as integration

### DIFF
--- a/tests/test_main_entrypoints.py
+++ b/tests/test_main_entrypoints.py
@@ -3,6 +3,7 @@
 import pytest
 
 
+@pytest.mark.integration
 def test_main_demo_outputs(capsys):
     """main.main should render the demo summary without errors."""
     import main


### PR DESCRIPTION
### Motivation

- A reviewer noted that `test_main_demo_outputs` behaves like an integration-style entrypoint test and should be discoverable/selectable using the standard pytest integration marker filters.

### Description

- Add `@pytest.mark.integration` above `test_main_demo_outputs` in `tests/test_main_entrypoints.py` so the test is part of the `integration` marker group.

### Testing

- Ran `pytest -q tests/test_main_entrypoints.py` and confirmed `4 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e87cd2dbd0832e9b2dc918106b9c92)