### PR TITLE
ci: add pre-test merge conflict marker guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,41 @@ permissions:
   pull-requests: read
 
 jobs:
+  conflict-marker-check:
+    runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Detect unresolved merge conflict markers
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          matches="$(
+            rg -n '^(<{7} .+|={7}|>{7} .+)$' . \
+              --glob '!.git/**' \
+              --glob '!outputs/**' \
+              --glob '!data/raw/**' \
+              --glob '!data/derived/**' \
+            || true
+          )"
+
+          if [[ -n "$matches" ]]; then
+            echo "Found unresolved merge conflict markers."
+            echo
+            echo "Offending files:"
+            echo "$matches" | cut -d: -f1 | sort -u
+            echo
+            echo "Matching lines:"
+            echo "$matches"
+            exit 1
+          fi
+
+          echo "No merge conflict markers detected."
+
   governance-and-repro:
     runs-on: ubuntu-latest
     env:
@@ -128,6 +163,7 @@ jobs:
           echo "CHANGELOG enforcement passed."
 
   test-suite:
+    needs: [conflict-marker-check]
     runs-on: ubuntu-latest
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true


### PR DESCRIPTION
### Motivation

- Prevent accidental merges with unresolved Git conflict markers from progressing to slow or confusing downstream failures. 
- Provide fast, clear feedback to contributors by failing early when conflict markers are present.

### Description

- Add a lightweight `conflict-marker-check` CI job that runs before the test matrix and checks the repository for unresolved merge conflict markers.  
- Use `rg` with the regex `^(<{7} .+|={7}|>{7} .+)$` to detect strict conflict-marker lines.  
- Exclude large/generated folders from the scan via `--glob '!.git/**'`, `--glob '!outputs/**'`, `--glob '!data/raw/**'`, and `--glob '!data/derived/**'`.  
- When matches are found, the job prints a deduplicated list of offending files and the matching lines and exits non-zero; the `test-suite` job is gated on this precheck via `needs`.

### Testing

- Ran the detection command `rg -n '^(<{7} .+|={7}|>{7} .+)$' . --glob '!.git/**' --glob '!outputs/**' --glob '!data/raw/**' --glob '!data/derived/**'` and confirmed no matches were reported (success).  
- Verified repository status with `git status --short` and inspected the last commit with `git show --stat --oneline HEAD` to ensure the workflow file change is present (commands succeeded).  
- No CI matrix tests were modified; the new job is lightweight and intended to fail early before the existing test-suite runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e896a50294832e829dcdc1c6a2194c)