### PR TITLE
Strengthen literature HTML test to validate rendered rows

### DIFF
--- a/tests/test_run_full_analysis.py
+++ b/tests/test_run_full_analysis.py
@@ -836,7 +836,7 @@ def test_generate_literature_html_creates_file(tmp_path: Path) -> None:
 
     literature = [
         Competence(
-            id="lit_1",
+            id="labor_justice_lit_1",
             name="Literature Competence",
             description="Test",
             axis=TMBDAxis.OCEANIC,
@@ -854,9 +854,8 @@ def test_generate_literature_html_creates_file(tmp_path: Path) -> None:
 
     assert output_file.exists()
     content = output_file.read_text()
-    # The HTML might not contain the competence name in the body table
-    # but should contain metadata about it
-    assert "Smith, J." in content or "Test Paper" in content or "OCEANIC" in content
+    assert "Literature Competence" in content
+    assert "Smith, J." in content
 
 
 def test_main_handles_missing_baseline_csv(tmp_path: Path) -> None:


### PR DESCRIPTION
### Motivation
- The existing test used a weak OR-based assertion that could succeed from axis badges (e.g. `OCEANIC`) even when per-theme literature rows were not rendered, so the test must verify that a competence matching a `LITERATURE_FILES` theme is actually rendered.

### Description
- Update `tests/test_run_full_analysis.py::test_generate_literature_html_creates_file` to use `id="labor_justice_lit_1"` (which matches a `LITERATURE_FILES` theme) and replace the previous OR assertion with explicit `assert "Literature Competence" in content` and `assert "Smith, J." in content`.

### Testing
- Ran `pytest -q tests/test_run_full_analysis.py -k test_generate_literature_html_creates_file` and it passed (`1 passed, 30 deselected`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8a0579090832e96a1e10ea2243c67)