### PR TITLE
fix: correct Python version check and restore live smoke test in run_research_api_full.ps1

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -19,6 +19,17 @@ Entries
 Unreleased
 Use this section for changes in progress that are not yet merged into the main branch. Move items to dated entries when merged.
 
+2026-04-28 (PowerShell research run fixes and UTF-8 validation hardening)
+Change type fix update add
+Scope scripts infra governance
+Files affected scripts/run_research_api_full.ps1 scripts/validate_generated_outputs.py outputs/research_source_capabilities.json MANIFEST_SOURCES.csv
+Summary (1) Fixed Python version guard in run_research_api_full.ps1: corrected capture-group indices (Groups[1]/Groups[2] instead of Groups[2]/Groups[3]) so Python 3.10+ is now enforced correctly. (2) Restored missing Step 5 live API smoke test in run_research_api_full.ps1 using RunCmd for consistent error handling and Test-Path/Remove-Item to cleanly restore the LIVE_RESEARCH_API_TESTS env var. (3) Added explicit UTF-8 encoding when reading JSON/CSV artifacts in scripts/validate_generated_outputs.py for cross-platform consistency. (4) Committed outputs/research_source_capabilities.json provider capability snapshot and regenerated MANIFEST_SOURCES.csv to include it.
+Reason The Python version guard was accepting Python 3.0–3.9 due to off-by-one capture-group indexing; Step 5 was silently skipped; validate_generated_outputs.py could fail on Windows due to encoding mismatch.
+Impact run_research_api_full.ps1 now correctly blocks Python <3.10 and executes the live smoke test when -Live is passed; validate_generated_outputs.py is encoding-safe on all platforms.
+Provenance PR review comments from copilot-pull-request-reviewer; CI governance-and-repro failure logs.
+Quality checks python -m pytest tests/ passed; MANIFEST_SOURCES.csv regenerated and committed.
+Reviewer GitHub Copilot Coding Agent
+
 2026-04-27 (Python version policy)
 Change type update fix
 Scope ci policy

--- a/MANIFEST_SOURCES.csv
+++ b/MANIFEST_SOURCES.csv
@@ -788,6 +788,7 @@ outputs/gaps_by_sector.html,other,,,,,,gaps_by_sector,no
 outputs/gaps_summary.csv,dataset_derived,,,,,,gaps_summary,yes
 outputs/literature_integration.html,other,,,,,,literature_integration,no
 outputs/report_index.html,other,,,,,,report_index,no
+outputs/research_source_capabilities.json,other,,,,,,research_source_capabilities,no
 outputs/sector_pathways.json,other,,,,,,sector_pathways,no
 PROMPT_REQUEST_TEMPLATE.txt,governance,,,,,,PROMPT_REQUEST_TEMPLATE,yes
 push_output.txt,text,,,,,,push_output,yes

--- a/outputs/research_source_capabilities.json
+++ b/outputs/research_source_capabilities.json
@@ -1,5 +1,4 @@
 {
-  "generated_at": "2026-04-28T16:11:36.162797+00:00",
   "note": "Provider capability snapshot. Values reflect runtime environment. Re-run after configuring additional provider credentials.",
   "providers": {
     "crossref": {

--- a/outputs/research_source_capabilities.json
+++ b/outputs/research_source_capabilities.json
@@ -1,0 +1,122 @@
+{
+  "generated_at": "2026-04-28T16:11:36.162797+00:00",
+  "note": "Provider capability snapshot. Values reflect runtime environment. Re-run after configuring additional provider credentials.",
+  "providers": {
+    "crossref": {
+      "provider": "Crossref",
+      "requires_secret": false,
+      "configured": true,
+      "live_test_allowed": false,
+      "allowed_metadata_fields": [
+        "title",
+        "authors",
+        "year",
+        "doi",
+        "journal",
+        "url",
+        "source_id",
+        "provider",
+        "source_query",
+        "retrieval_timestamp"
+      ],
+      "licence_note": "Crossref metadata is freely redistributable. Do not store restricted publisher full-text."
+    },
+    "scopus": {
+      "provider": "Elsevier / Scopus",
+      "requires_secret": true,
+      "configured": false,
+      "live_test_allowed": false,
+      "allowed_metadata_fields": [
+        "title",
+        "authors",
+        "year",
+        "doi",
+        "journal",
+        "url",
+        "citation_count",
+        "subject_terms",
+        "source_id",
+        "provider",
+        "source_query",
+        "retrieval_timestamp"
+      ],
+      "licence_note": "Store only title, authors, year, DOI, journal, URL, citation count, and subject terms unless institutional licence permits additional fields."
+    },
+    "wos": {
+      "provider": "Web of Science (Clarivate)",
+      "requires_secret": true,
+      "configured": false,
+      "live_test_allowed": false,
+      "allowed_metadata_fields": [
+        "title",
+        "authors",
+        "year",
+        "doi",
+        "journal",
+        "url",
+        "citation_count",
+        "subject_terms",
+        "source_id",
+        "provider",
+        "source_query",
+        "retrieval_timestamp"
+      ],
+      "licence_note": "Store only permitted bibliographic fields; do not store full WoS database payloads."
+    },
+    "scival": {
+      "provider": "Elsevier SciVal",
+      "requires_secret": true,
+      "configured": false,
+      "live_test_allowed": false,
+      "allowed_metadata_fields": [
+        "title",
+        "authors",
+        "year",
+        "doi",
+        "journal",
+        "subject_terms",
+        "source_id",
+        "provider",
+        "source_query",
+        "retrieval_timestamp"
+      ],
+      "licence_note": "SciVal analytics data: store only permitted aggregated indicators, not restricted database payloads."
+    },
+    "google_drive": {
+      "provider": "Google Drive",
+      "requires_secret": true,
+      "configured": false,
+      "live_test_allowed": false,
+      "allowed_metadata_fields": [
+        "title",
+        "authors",
+        "year",
+        "doi",
+        "url",
+        "source_id",
+        "provider",
+        "source_query",
+        "retrieval_timestamp"
+      ],
+      "licence_note": "Store only sanitized metadata exported from Drive; never commit OAuth credentials to the repository."
+    },
+    "microsoft_graph": {
+      "provider": "Microsoft Graph (OneDrive/SharePoint)",
+      "requires_secret": true,
+      "configured": false,
+      "live_test_allowed": false,
+      "allowed_metadata_fields": [
+        "title",
+        "authors",
+        "year",
+        "doi",
+        "url",
+        "source_id",
+        "provider",
+        "source_query",
+        "retrieval_timestamp"
+      ],
+      "licence_note": "Store only sanitized metadata exported from OneDrive/SharePoint; never commit tenant IDs or app secrets to the repository."
+    }
+  }
+}

--- a/scripts/run_research_api_full.ps1
+++ b/scripts/run_research_api_full.ps1
@@ -37,8 +37,8 @@ try {
     Write-Host $pyVersion
     $match = [regex]::Match($pyVersion, "Python (\d+)\.(\d+)")
     if ($match.Success) {
-        $major = [int]$match.Groups[2].Value
-        $minor = [int]$match.Groups[3].Value
+        $major = [int]$match.Groups[1].Value
+        $minor = [int]$match.Groups[2].Value
         if ($major -lt 3 -or ($major -eq 3 -and $minor -lt 10)) {
             Write-Error "Python 3.10+ required. Found: $pyVersion"
             exit 1
@@ -55,6 +55,20 @@ try {
 
     Step "Step 4: Offline smoke test"
     RunCmd "python" @("scripts/smoke_scientific_bridge.py", "--offline")
+
+    Step "Step 5: Live API smoke test (requires Python 3.10+)"
+    if ($LiveMode) {
+        $oldLive = $env:LIVE_RESEARCH_API_TESTS
+        try {
+            $env:LIVE_RESEARCH_API_TESTS = 'true'
+            python scripts/smoke_scientific_bridge.py --live-if-secrets-present
+            if ($LASTEXITCODE -ne 0) { throw "Live smoke test failed." }
+        } finally {
+            $env:LIVE_RESEARCH_API_TESTS = $oldLive
+        }
+    } else {
+        Write-Host "SKIPPED (pass -Live to enable)"
+    }
 
     Step "Step 6: Full analysis"
     RunCmd "python" @("run_full_analysis.py")

--- a/scripts/run_research_api_full.ps1
+++ b/scripts/run_research_api_full.ps1
@@ -61,8 +61,7 @@ try {
         $oldLive = $env:LIVE_RESEARCH_API_TESTS
         try {
             $env:LIVE_RESEARCH_API_TESTS = 'true'
-            python scripts/smoke_scientific_bridge.py --live-if-secrets-present
-            if ($LASTEXITCODE -ne 0) { throw "Live smoke test failed." }
+            RunCmd "python" @("scripts/smoke_scientific_bridge.py", "--live-if-secrets-present")
         } finally {
             $env:LIVE_RESEARCH_API_TESTS = $oldLive
         }

--- a/scripts/run_research_api_full.ps1
+++ b/scripts/run_research_api_full.ps1
@@ -1,148 +1,75 @@
-<#
+﻿<#
 .SYNOPSIS
-    One-command full research run for morskamary (PowerShell).
-
+One-command full research run for morskamary.
 .DESCRIPTION
-    Steps:
-      1. Check Python version (>= 3.9 required)
-      2. Install / update the package
-      3. Check research environment
-      4. Offline smoke test
-      5. Optional live API tests (-Live switch or $env:LIVE_RESEARCH_API_TESTS=true)
-      6. Full analysis
-      7. Export provider capabilities
-      8. Validate research source outputs
-      9. Print summary
-
-.PARAMETER Live
-    Enable live proprietary API calls (requires configured provider credentials).
-
-.EXAMPLE
-    .\scripts\run_research_api_full.ps1           # offline only
-    .\scripts\run_research_api_full.ps1 -Live     # enable live API calls
-
-.NOTES
-    Load credentials first:
-      . .\.env.ps1   # if you used bootstrap_research_secrets.ps1 -Backend DotEnv
-    See docs/ONE_CLICK_RESEARCH_RUNBOOK.md for the full workflow.
+ASCII-safe Windows PowerShell version.
+Requires Python 3.10 or newer.
 #>
-
 [CmdletBinding()]
-param(
-    [switch]$Live
-)
-
+param([switch]$Live)
 Set-StrictMode -Version Latest
-$ErrorActionPreference = 'Stop'
-
-$LiveMode = $Live.IsPresent -or ($env:LIVE_RESEARCH_API_TESTS -ieq 'true')
+$ErrorActionPreference = "Stop"
+$LiveMode = $Live.IsPresent -or ($env:LIVE_RESEARCH_API_TESTS -ieq "true")
 $RepoRoot = Split-Path -Parent $PSScriptRoot
 
-function Step([string]$Title) {
-    Write-Host ""
-    Write-Host "--- $Title ---" -ForegroundColor Cyan
+function Step {
+    param([string]$Title)
+    Write-Host "`n--- $Title ---" -ForegroundColor Cyan
 }
 
-function RunPy([string]$Script, [hashtable]$Env = @{}) {
-    $oldEnv = @{}
-    foreach ($k in $Env.Keys) {
-        $oldEnv[$k] = [System.Environment]::GetEnvironmentVariable($k)
-        [System.Environment]::SetEnvironmentVariable($k, $Env[$k])
-    }
-    try {
-        python $Script
-        if ($LASTEXITCODE -ne 0) { throw "Script $Script failed with exit code $LASTEXITCODE" }
-    } finally {
-        foreach ($k in $oldEnv.Keys) {
-            [System.Environment]::SetEnvironmentVariable($k, $oldEnv[$k])
-        }
+function RunCmd {
+    param([string]$Exe, [string[]]$CmdArgs)
+    & $Exe @CmdArgs
+    if ($LASTEXITCODE -ne 0) {
+        throw "$Exe $($CmdArgs -join ' ') failed with exit code $LASTEXITCODE"
     }
 }
 
 Write-Host "=============================================" -ForegroundColor Green
-Write-Host "  morskamary — Full Research Run (PowerShell)" -ForegroundColor Green
-Write-Host "  Live API: $(if ($LiveMode) { 'ENABLED' } else { 'DISABLED' })" -ForegroundColor Green
+Write-Host " morskamary - Full Research Run" -ForegroundColor Green
+Write-Host " Live API: $(if ($LiveMode) { 'ENABLED' } else { 'DISABLED' })" -ForegroundColor Green
 Write-Host "=============================================" -ForegroundColor Green
 
 Push-Location $RepoRoot
 try {
-
-    # Step 1: Python version check
     Step "Step 1: Python version"
     $pyVersion = python --version 2>&1
     Write-Host $pyVersion
-    $match = [regex]::Match($pyVersion, 'Python (\d+)\.(\d+)')
+    $match = [regex]::Match($pyVersion, "Python (\d+)\.(\d+)")
     if ($match.Success) {
-        $major = [int]$match.Groups[1].Value
-        $minor = [int]$match.Groups[2].Value
-        if ($major -lt 3 -or ($major -eq 3 -and $minor -lt 9)) {
-            Write-Error "Python 3.9+ required. Found: $pyVersion"
+        $major = [int]$match.Groups[2].Value
+        $minor = [int]$match.Groups[3].Value
+        if ($major -lt 3 -or ($major -eq 3 -and $minor -lt 10)) {
+            Write-Error "Python 3.10+ required. Found: $pyVersion"
             exit 1
         }
     }
 
-    # Step 2: Install/update package
     Step "Step 2: Install dependencies"
-    python -m pip install --upgrade pip --quiet
-    python -m pip install -e ".[dev]" --quiet
+    RunCmd "python" @("-m", "pip", "install", "--upgrade", "pip", "--quiet")
+    RunCmd "python" @("-m", "pip", "install", "-e", ".[dev]", "--quiet")
     Write-Host "Package installed."
 
-    # Step 3: Environment check
     Step "Step 3: Environment check"
-    RunPy "scripts/check_research_env.py"
+    RunCmd "python" @("scripts/check_research_env.py")
 
-    # Step 4: Offline smoke test (always)
     Step "Step 4: Offline smoke test"
-    python scripts/smoke_scientific_bridge.py --offline
-    if ($LASTEXITCODE -ne 0) { throw "Offline smoke test failed." }
+    RunCmd "python" @("scripts/smoke_scientific_bridge.py", "--offline")
 
-    # Step 5: Live API smoke (optional)
-    Step "Step 5: Live API smoke test"
-    if ($LiveMode) {
-        $env:LIVE_RESEARCH_API_TESTS = 'true'
-        python scripts/smoke_scientific_bridge.py --live-if-secrets-present
-        if ($LASTEXITCODE -ne 0) { throw "Live smoke test failed." }
-        $env:LIVE_RESEARCH_API_TESTS = 'false'
-    } else {
-        Write-Host "SKIPPED (pass -Live to enable)"
-    }
-
-    # Step 6: Full analysis
     Step "Step 6: Full analysis"
-    python run_full_analysis.py
-    if ($LASTEXITCODE -ne 0) { throw "run_full_analysis.py failed." }
-    python scripts/validate_generated_outputs.py
-    if ($LASTEXITCODE -ne 0) { throw "validate_generated_outputs.py failed." }
+    RunCmd "python" @("run_full_analysis.py")
+    RunCmd "python" @("scripts/validate_generated_outputs.py")
 
-    # Step 7: Export capabilities
     Step "Step 7: Export provider capabilities"
-    python scripts/export_research_source_capabilities.py
-    if ($LASTEXITCODE -ne 0) { throw "export_research_source_capabilities.py failed." }
+    RunCmd "python" @("scripts/export_research_source_capabilities.py")
 
-    # Step 8: Validate research outputs
     Step "Step 8: Validate research source outputs"
-    python scripts/validate_research_source_outputs.py
-    if ($LASTEXITCODE -ne 0) { throw "validate_research_source_outputs.py failed." }
+    RunCmd "python" @("scripts/validate_research_source_outputs.py")
 
-    # Step 9: Summary
-    Write-Host ""
-    Write-Host "=============================================" -ForegroundColor Green
-    Write-Host "  Run complete." -ForegroundColor Green
-    Write-Host ""
-    Write-Host "  Configured providers:"
-    python scripts/audit_research_api_config.py 2>&1 | Where-Object { $_ -match '✓|✗' } | Select-Object -First 10
-    Write-Host ""
-    Write-Host "  Next steps:"
-    if (-not $LiveMode) {
-        Write-Host "  - Run with -Live to enable live API calls:"
-        Write-Host "    .\scripts\run_research_api_full.ps1 -Live"
-    }
-    Write-Host "  - Run Cloud Build offline mirror:"
-    Write-Host "    .\scripts\run_cloudbuild_research_full.ps1 -Offline"
-    Write-Host "  - Run Cloud Build live mirror (requires secrets):"
-    Write-Host "    .\scripts\run_cloudbuild_research_full.ps1 -Live"
-    Write-Host "=============================================" -ForegroundColor Green
-
+    Step "Step 9: Summary"
+    Write-Host "`nRun complete." -ForegroundColor Green
+    Write-Host "`nConfigured providers:"
+    RunCmd "python" @("scripts/audit_research_api_config.py")
 } finally {
     Pop-Location
 }

--- a/scripts/run_research_api_full.ps1
+++ b/scripts/run_research_api_full.ps1
@@ -2,7 +2,7 @@
 .SYNOPSIS
 One-command full research run for morskamary.
 .DESCRIPTION
-ASCII-safe Windows PowerShell version.
+Windows PowerShell version.
 Requires Python 3.10 or newer.
 #>
 [CmdletBinding()]

--- a/scripts/run_research_api_full.ps1
+++ b/scripts/run_research_api_full.ps1
@@ -58,12 +58,17 @@ try {
 
     Step "Step 5: Live API smoke test (requires Python 3.10+)"
     if ($LiveMode) {
+        $hadOldLive = Test-Path Env:LIVE_RESEARCH_API_TESTS
         $oldLive = $env:LIVE_RESEARCH_API_TESTS
         try {
             $env:LIVE_RESEARCH_API_TESTS = 'true'
             RunCmd "python" @("scripts/smoke_scientific_bridge.py", "--live-if-secrets-present")
         } finally {
-            $env:LIVE_RESEARCH_API_TESTS = $oldLive
+            if ($hadOldLive) {
+                $env:LIVE_RESEARCH_API_TESTS = $oldLive
+            } else {
+                Remove-Item Env:LIVE_RESEARCH_API_TESTS -ErrorAction SilentlyContinue
+            }
         }
     } else {
         Write-Host "SKIPPED (pass -Live to enable)"

--- a/scripts/validate_generated_outputs.py
+++ b/scripts/validate_generated_outputs.py
@@ -77,7 +77,7 @@ def load_competences(path: Path) -> dict[str, dict]:
 
     Fails loudly if required top-level keys or per-entry fields are absent.
     """
-    with path.open() as f:
+    with path.open(encoding="utf-8") as f:
         data = json.load(f)
 
     if not isinstance(data, dict):
@@ -126,7 +126,7 @@ def load_credentials(path: Path) -> list[dict]:
 
     Fails loudly if required top-level key or per-entry fields are absent.
     """
-    with path.open() as f:
+    with path.open(encoding="utf-8") as f:
         data = json.load(f)
 
     if not isinstance(data, dict):
@@ -170,7 +170,7 @@ def load_gaps_csv(path: Path) -> list[dict]:
 
     Fails loudly if required columns are absent.
     """
-    with path.open(newline="") as f:
+    with path.open(newline="", encoding="utf-8") as f:
         reader = csv.DictReader(f)
         rows = list(reader)
 
@@ -195,7 +195,7 @@ def load_sector_dict_ids(path: Path) -> set[str]:
     Raises ValueError with a clear message if the dictionary schema is
     unreadable or yields no IDs.
     """
-    with path.open() as f:
+    with path.open(encoding="utf-8") as f:
         data = json.load(f)
 
     if not isinstance(data, dict):


### PR DESCRIPTION
## Summary

Two bugs fixed in `scripts/run_research_api_full.ps1` to align PowerShell behaviour with the Bash version.

### 1. Python version guard — wrong capture groups & wrong threshold

**Before:**
```powershell
$major = [int]$match.Groups[2].Value   # off-by-one: Group[0] is the full match
$minor = [int]$match.Groups[3].Value   # Group[3] doesn't exist → always 0
if ($major -lt 3 -or ($major -eq 3 -and $minor -lt 10)) { ... }
```
Because `Groups[3]` is always null/0, the guard accepted Python 3.0.x – 3.9.x.

**After:**
```powershell
$major = [int]$match.Groups[1].Value
$minor = [int]$match.Groups[2].Value
if ($major -lt 3 -or ($major -eq 3 -and $minor -lt 10)) {
    Write-Error "Python 3.10+ required. Found: $pyVersion"
    exit 1
}
```

### 2. Step 5 — live smoke test was missing entirely

The step header existed but the script jumped straight from Step 4 to Step 6 without calling `smoke_scientific_bridge.py --live-if-secrets-present`.

**After:** Step 5 now calls the smoke test when `-Live` is passed (or `LIVE_RESEARCH_API_TESTS=true`), wrapped in a `try/finally` to restore the environment variable regardless of outcome.

```powershell
Step "Step 5: Live API smoke test (requires Python 3.10+)"
if ($LiveMode) {
    $oldLive = $env:LIVE_RESEARCH_API_TESTS
    try {
        $env:LIVE_RESEARCH_API_TESTS = 'true'
        python scripts/smoke_scientific_bridge.py --live-if-secrets-present
        if ($LASTEXITCODE -ne 0) { throw "Live smoke test failed." }
    } finally {
        $env:LIVE_RESEARCH_API_TESTS = $oldLive
    }
} else {
    Write-Host "SKIPPED (pass -Live to enable)"
}
```