### PR TITLE
fix: dedupe DOI/title, preserve provider identity for zero-hits, and optimize low-confidence filtering

### DIFF
--- a/docs/ONE_CLICK_RESEARCH_RUNBOOK.md
+++ b/docs/ONE_CLICK_RESEARCH_RUNBOOK.md
@@ -223,7 +223,7 @@ python scripts/export_live_research_records.py \
   --output-dir outputs/research_sources \
   --offline true
 
-# Live export (requires provider credentials)
+# Live export (Crossref requires no API key; proprietary providers may require credentials)
 python scripts/export_live_research_records.py \
   --providers crossref \
   --query-file config/research_queries.yml \
@@ -354,4 +354,3 @@ Use Microsoft Entra / Azure App Registration. Collect:
 - `MICROSOFT_CLIENT_SECRET`
 
 Do not commit client secrets.
-

--- a/scripts/export_live_research_records.py
+++ b/scripts/export_live_research_records.py
@@ -70,10 +70,12 @@ def deduplicate_records(
     for rec in records:
         # DOI dedup (if DOI is present)
         if rec.doi:
-            if rec.doi in seen_dois:
+            doi_key = rec.doi.strip().lower()
+            if doi_key in seen_dois:
                 stats["doi_duplicates"] += 1
                 continue
-            seen_dois.add(rec.doi)
+            seen_dois.add(doi_key)
+            seen_titles.add(normalize_title(rec.title))
             deduped.append(rec)
         else:
             # Title dedup (if no DOI)
@@ -295,15 +297,25 @@ def main() -> int:
                     query, max_results=args.max_results_per_query, providers=provider_list
                 )
 
-                for result in results:
+                for i, result in enumerate(results):
+                    provider_name = (
+                        provider_list[i]
+                        if i < len(provider_list)
+                        else (
+                            result.records[0].provider
+                            if result.records
+                            else (
+                                result.provenance[0].source_provider
+                                if result.provenance
+                                else "unknown"
+                            )
+                        )
+                    )
                     if result.errors:
                         print(f"    Errors: {result.errors}", file=sys.stderr)
                     if result.warnings:
                         print(f"    Warnings: {result.warnings}")
 
-                    provider_name = (
-                        result.records[0].provider if result.records else "unknown"
-                    )
                     all_coverage_items.append(
                         {
                             "sector": sector_label,
@@ -331,10 +343,11 @@ def main() -> int:
     crossref_records = [r for r in deduped_records if r.provider == "Crossref"]
 
     # Filter low-confidence records
+    low_confidence_record_ids: Set[str] = {
+        p.record_id for p in all_provenance if p.confidence_score < 0.8
+    }
     low_confidence_records = [
-        r
-        for r in deduped_records
-        if any(p.record_id == r.source_id and p.confidence_score < 0.8 for p in all_provenance)
+        r for r in deduped_records if r.source_id in low_confidence_record_ids
     ]
 
     # Build coverage report


### PR DESCRIPTION
### Motivation

- Ensure the exporter follows the intended "DOI first, then title" deduplication policy and avoids leaking duplicates when providers differ in DOI coverage.  
- Make `live_source_coverage.csv` accurate even when a provider returns zero records so downstream coverage analysis can distinguish queried providers from unqueried ones.  
- Improve scalability of low-confidence filtering to avoid repeated nested scans over provenance for large exports.

### Description

- Normalized DOI keys for deduplication by using `rec.doi.strip().lower()` and registered DOI-accepted records' normalized titles so title-only duplicates are removed after DOI deduplication in `deduplicate_records` in `scripts/export_live_research_records.py`.  
- Preserved provider identity for zero-hit results by iterating provider results with the requested provider list index and falling back to record/provenance provider labels when needed in the query loop in `scripts/export_live_research_records.py`.  
- Optimized low-confidence filtering by precomputing a set of low-confidence `record_id`s from `all_provenance` and filtering `deduped_records` by membership instead of scanning `all_provenance` repeatedly.  
- Clarified runbook wording in `docs/ONE_CLICK_RESEARCH_RUNBOOK.md` to state that Crossref does not require an API key while proprietary providers may require credentials.  
- Files changed: `scripts/export_live_research_records.py`, `docs/ONE_CLICK_RESEARCH_RUNBOOK.md`.

### Testing

- Ran the unit/integration test suite for the exporter with `pytest -q tests/test_export_live_research_records.py`, and all tests passed (`20 passed`).  
- Verified exporter CLI behavior in offline mode and that `live_records.json`, `crossref_records.json`, `live_provenance.json`, `live_source_coverage.csv`, and `low_confidence_live_records.json` are produced by the script during the test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f225a1867c832ea5892fbab1ae2b44)