### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -3,6 +3,9 @@ name: CI (disabled - canonical is ci.yml)
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/robertbartlomiejski/morskamary/security/code-scanning/3](https://github.com/robertbartlomiejski/morskamary/security/code-scanning/3)

Add an explicit `permissions` block to `.github/workflows/blank.yml` so the workflow does not inherit potentially broad defaults.  
Best fix without changing functionality: set workflow-level permissions to the minimum required for this pipeline:

- `contents: read`

This allows `actions/checkout` to read repository contents and keeps the token least-privileged for all jobs in this workflow. Place it at the root level (after `on:` or before `jobs:`), so it applies consistently to the `test` job unless overridden later.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
