### PR TITLE
Follow-up: fix provider mapping for coverage rows in PR #107

### DIFF
--- a/scripts/export_live_research_records.py
+++ b/scripts/export_live_research_records.py
@@ -297,10 +297,21 @@ def main() -> int:
                     query, max_results=args.max_results_per_query, providers=provider_list
                 )
 
+                queried_provider_names = [
+                    cap.name
+                    for cap in registry.list_capabilities()
+                    if cap.name in provider_list
+                ]
+
                 for i, result in enumerate(results):
+                    mapped_provider = (
+                        queried_provider_names[i]
+                        if i < len(queried_provider_names)
+                        else None
+                    )
                     provider_name = (
-                        provider_list[i]
-                        if i < len(provider_list)
+                        mapped_provider
+                        if mapped_provider
                         else (
                             result.records[0].provider
                             if result.records

--- a/scripts/export_live_research_records.py
+++ b/scripts/export_live_research_records.py
@@ -286,6 +286,12 @@ def main() -> int:
         print(
             f"Fetching records for {len(query_groups)} sectors with providers: {provider_list}"
         )
+        provider_set = set(provider_list)
+        queried_provider_names = [
+            cap.name
+            for cap in registry.list_capabilities()
+            if cap.name in provider_set
+        ]
         for sector_key, sector_data in query_groups.items():
             sector_label = sector_data.get("label", sector_key)
             queries = sector_data.get("queries", [])
@@ -296,12 +302,6 @@ def main() -> int:
                 results = registry.search(
                     query, max_results=args.max_results_per_query, providers=provider_list
                 )
-
-                queried_provider_names = [
-                    cap.name
-                    for cap in registry.list_capabilities()
-                    if cap.name in provider_list
-                ]
 
                 for i, result in enumerate(results):
                     mapped_provider = (


### PR DESCRIPTION
### Motivation

- Fix a high-priority bug where coverage rows in `live_source_coverage.csv` could be attributed to the wrong provider when the CLI `--providers` order differed from the internal `SourceRegistry` order.

### Description

- Compute `queried_provider_names` from `registry.list_capabilities()` filtered by the requested `provider_list` and map each `ProviderResult` to the corresponding provider name from that list, falling back to `result.records[0].provider` or `result.provenance[0].source_provider` when needed in `scripts/export_live_research_records.py`.

### Testing

- Ran `pytest -q tests/test_export_live_research_records.py` but test collection failed in this environment due to a missing dependency (`ModuleNotFoundError: No module named 'yaml'`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f319edfdb0832e8777cac0dfc60ae2)