### PR TITLE
fix: handle empty provider results without attribute errors

### DIFF
--- a/scripts/export_live_research_records.py
+++ b/scripts/export_live_research_records.py
@@ -273,6 +273,14 @@ def main() -> int:
     # Initialize registry
     registry = SourceRegistry()
 
+    # Provider names in the same order SourceRegistry.search() uses.
+    registry_provider_order = [cap.name for cap in registry.list_capabilities()]
+    queried_providers = (
+        [name for name in registry_provider_order if name in provider_list]
+        if provider_list
+        else registry_provider_order
+    )
+
     # Storage for all results
     all_records: List[LiteratureRecord] = []
     all_provenance: List[SourceEvidence] = []
@@ -299,8 +307,8 @@ def main() -> int:
 
                 for i, result in enumerate(results):
                     provider_name = (
-                        provider_list[i]
-                        if i < len(provider_list)
+                        queried_providers[i]
+                        if i < len(queried_providers)
                         else (
                             result.records[0].provider
                             if result.records

--- a/scripts/export_live_research_records.py
+++ b/scripts/export_live_research_records.py
@@ -275,11 +275,14 @@ def main() -> int:
 
     # Provider names in the same order SourceRegistry.search() uses.
     registry_provider_order = [cap.name for cap in registry.list_capabilities()]
-    queried_providers = (
-        [name for name in registry_provider_order if name in provider_list]
-        if provider_list
-        else registry_provider_order
-    )
+    if provider_list:
+        queried_providers = [
+            name for name in registry_provider_order if name in provider_list
+        ]
+        if not queried_providers:
+            queried_providers = list(provider_list)
+    else:
+        queried_providers = registry_provider_order
 
     # Storage for all results
     all_records: List[LiteratureRecord] = []


### PR DESCRIPTION
### Motivation

- Prevent the exporter from crashing when a provider returns zero records due to accessing a non-existent `ProviderResult.provider` attribute.
- Ensure coverage rows report provider names that align with the ordering used by `SourceRegistry.search()` so exported coverage is stable and accurate.

### Description

- Compute `registry_provider_order` from `registry.list_capabilities()` and derive `queried_providers` from the requested providers or registry order in `scripts/export_live_research_records.py`.
- Use `queried_providers[i]` as the primary provider name when building coverage rows instead of the previous index into the user `provider_list`, while retaining defensive fallbacks to `record.provider`, provenance `source_provider`, and `"unknown"`.
- The change is limited to `scripts/export_live_research_records.py` and ensures callers never depend on a non-existent `ProviderResult.provider` attribute.

### Testing

- Ran the targeted test file with `python -m pytest tests/test_export_live_research_records.py` and test collection failed in this environment due to a missing dependency: `ModuleNotFoundError: No module named 'yaml'`.
- No additional automated tests were executed in this environment after the change due to the dependency issue.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f319f17698832e8b3c1ccc19d636f8)