### PR TITLE
[PR #105 follow-up] Fix DOI/title dedup order in live research export

### DIFF
--- a/scripts/export_live_research_records.py
+++ b/scripts/export_live_research_records.py
@@ -68,6 +68,7 @@ def deduplicate_records(
     stats = {"doi_duplicates": 0, "title_duplicates": 0}
 
     for rec in records:
+        norm_title = normalize_title(rec.title)
         # DOI dedup (if DOI is present)
         if rec.doi:
             doi_key = rec.doi.strip().lower()
@@ -75,16 +76,11 @@ def deduplicate_records(
                 stats["doi_duplicates"] += 1
                 continue
             seen_dois.add(doi_key)
-            seen_titles.add(normalize_title(rec.title))
-            deduped.append(rec)
-        else:
-            # Title dedup (if no DOI)
-            norm_title = normalize_title(rec.title)
-            if norm_title in seen_titles:
-                stats["title_duplicates"] += 1
-                continue
-            seen_titles.add(norm_title)
-            deduped.append(rec)
+        if norm_title in seen_titles:
+            stats["title_duplicates"] += 1
+            continue
+        seen_titles.add(norm_title)
+        deduped.append(rec)
 
     return deduped, stats
 

--- a/tests/test_export_live_research_records.py
+++ b/tests/test_export_live_research_records.py
@@ -124,10 +124,19 @@ class TestDeduplicateRecords:
         rec2 = _make_record(doi="", title="BLUE ECONOMY: GOVERNANCE!")
         deduped, stats = deduplicate_records([rec1, rec2])
         assert len(deduped) == 1
+        assert deduped[0].doi == "10.1234/x"
         assert stats["doi_duplicates"] == 0
         assert stats["title_duplicates"] == 1
 
-
+    def test_prefers_doi_record_for_title_duplicate_regardless_of_order(self):
+        """Title dedup should prefer the DOI-bearing variant regardless of input order."""
+        rec1 = _make_record(doi="", title="BLUE ECONOMY: GOVERNANCE!")
+        rec2 = _make_record(doi="10.1234/x", title="Blue Economy Governance")
+        deduped, stats = deduplicate_records([rec1, rec2])
+        assert len(deduped) == 1
+        assert deduped[0].doi == "10.1234/x"
+        assert stats["doi_duplicates"] == 0
+        assert stats["title_duplicates"] == 1
 class TestBuildCoverageReport:
     def test_builds_coverage_rows(self):
         items = [

--- a/tests/test_export_live_research_records.py
+++ b/tests/test_export_live_research_records.py
@@ -118,6 +118,15 @@ class TestDeduplicateRecords:
         assert len(deduped) == 1
         assert stats["doi_duplicates"] == 2
 
+    def test_removes_title_duplicate_when_only_one_record_has_doi(self):
+        """Title dedup must still run when one variant has DOI and one does not."""
+        rec1 = _make_record(doi="10.1234/x", title="Blue Economy Governance")
+        rec2 = _make_record(doi="", title="BLUE ECONOMY: GOVERNANCE!")
+        deduped, stats = deduplicate_records([rec1, rec2])
+        assert len(deduped) == 1
+        assert stats["doi_duplicates"] == 0
+        assert stats["title_duplicates"] == 1
+
 
 class TestBuildCoverageReport:
     def test_builds_coverage_rows(self):


### PR DESCRIPTION
### Motivation
- A deduplication bug caused normalized-title deduplication to run only for records without a DOI, allowing duplicates when one provider supplied a DOI and another provider returned the same title without DOI.
- The intended strategy is "DOI first, then title", meaning title-based deduplication must still apply after accepting DOI-bearing records.

### Description
- Updated `deduplicate_records` in `scripts/export_live_research_records.py` to compute the normalized title at the start of each loop and apply title deduplication for every accepted record (DOI check still runs first). 
- Removed the previous branch that only ran title deduplication for no-DOI records so title collisions are detected regardless of DOI presence. 
- Added a regression test `test_removes_title_duplicate_when_only_one_record_has_doi` to `tests/test_export_live_research_records.py` that verifies a DOI-bearing record and a title-equivalent no-DOI record deduplicate to a single record. 
- Changed behavior preserves DOI-priority while preventing duplicate retention across providers that vary in DOI completeness.

### Testing
- Ran `pytest -q tests/test_export_live_research_records.py` in this environment, but test collection failed due to a missing environment dependency: `ModuleNotFoundError: No module named 'yaml'` (CI/normal environments with project dependencies should allow the suite to run). 
- The new unit test exercise covers the DOI + no-DOI title-duplicate scenario and is expected to pass once test dependencies are installed. 
- No other automated test failures were observed in this run because collection did not complete due to the missing dependency.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f319fd7ee8832e86010e17d0f47f9b)