### PR TITLE
Add CI preflight API health checks and status reporting

### DIFF
--- a/.github/workflows/export-research-records.yml
+++ b/.github/workflows/export-research-records.yml
@@ -44,6 +44,13 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e .
 
+      - name: Research API preflight health check
+        if: github.event.inputs.offline != 'true'
+        run: |
+          python scripts/check_research_api_health.py \
+            --require-valid \
+            --output outputs/research_api_health.json
+
       - name: Export live research records
         run: |
           python scripts/export_live_research_records.py \
@@ -57,7 +64,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: research-sources-${{ github.run_number }}
-          path: outputs/research_sources/
+          path: |
+            outputs/research_sources/
+            outputs/research_api_health.json
           retention-days: 30
           if-no-files-found: warn
 

--- a/.github/workflows/research-api-smoke.yml
+++ b/.github/workflows/research-api-smoke.yml
@@ -52,6 +52,9 @@ jobs:
           WOS_API_KEY: ${{ secrets.WOS_API_KEY }}
           SCIVAL_API_KEY: ${{ secrets.SCIVAL_API_KEY }}
         run: |
+          python scripts/check_research_api_health.py \
+            --require-valid \
+            --output outputs/research_api_health.json
           LIVE_RESEARCH_API_TESTS=true \
             python scripts/smoke_scientific_bridge.py --live-if-secrets-present
 
@@ -68,6 +71,8 @@ jobs:
         if: always()
         with:
           name: research-source-capabilities
-          path: outputs/research_source_capabilities.json
+          path: |
+            outputs/research_source_capabilities.json
+            outputs/research_api_health.json
           if-no-files-found: warn
           retention-days: 7

--- a/docs/ONE_CLICK_RESEARCH_RUNBOOK.md
+++ b/docs/ONE_CLICK_RESEARCH_RUNBOOK.md
@@ -75,6 +75,7 @@ To make credentials persistent across sessions, add to your shell profile:
 
 ```bash
 python scripts/check_research_env.py
+python scripts/check_research_api_health.py --output outputs/research_api_health.json
 ```
 
 ### 4. Run offline smoke test (no API keys required)
@@ -207,6 +208,27 @@ gh secret list
 The `.github/workflows/research-api-smoke.yml` workflow runs on
 `workflow_dispatch` only and requires `LIVE_RESEARCH_API_TESTS=true` to
 make live API calls.
+
+## Preflight credential health statuses
+
+`scripts/check_research_api_health.py` returns one of:
+
+- `missing` — credential not provided.
+- `present-but-invalid` — key present but rejected/unauthorized.
+- `rate-limited` — provider throttled request.
+- `ok` — authenticated probe succeeded.
+
+Use `--require-valid` in CI/live runs to fail fast on invalid or throttled
+credentials before long-running export workflows.
+
+### Troubleshooting revoked/cancelled credentials
+
+If status is `present-but-invalid`:
+
+1. Confirm the account/subscription is still active in provider admin.
+2. Regenerate or un-revoke API key/token.
+3. Update local `.env` / GitHub Actions secret / Secret Manager value.
+4. Re-run `python scripts/check_research_api_health.py --require-valid`.
 
 ---
 

--- a/docs/RESEARCH_API_CICD_SETUP.md
+++ b/docs/RESEARCH_API_CICD_SETUP.md
@@ -53,6 +53,7 @@ Quick start:
 pip install -e .[dev]
 ./scripts/bootstrap_research_secrets.sh --backend dotenv
 python scripts/check_research_env.py
+python scripts/check_research_api_health.py --output outputs/research_api_health.json
 python scripts/smoke_scientific_bridge.py --offline
 ```
 
@@ -93,3 +94,30 @@ After running `terraform apply` in `infra/gcp-mirror/`:
 4. Store only permitted bibliographic metadata, not restricted database payloads.
 5. Live API tests must be explicitly enabled (`LIVE_RESEARCH_API_TESTS=true`).
 6. GitHub Actions primary CI must pass without any external API keys.
+
+## Preflight API health gate (CI)
+
+Before live export workflows, CI now runs `scripts/check_research_api_health.py`
+to validate provider credentials with lightweight authenticated requests.
+
+- Statuses are explicit and machine-readable: `missing`, `present-but-invalid`,
+  `rate-limited`, `ok`.
+- The script does **not** print secret values and writes a sanitized artifact:
+  `outputs/research_api_health.json`.
+- In CI, `--require-valid` fails fast when any enabled provider is
+  `present-but-invalid` or `rate-limited`.
+
+### Troubleshooting revoked/cancelled API configs
+
+If a provider moves from `ok` to `present-but-invalid`, usually one of:
+
+1. API key revoked or rotated by provider admin.
+2. Subscription expired/cancelled (license removed).
+3. Key scope no longer includes requested endpoint.
+
+Recommended response:
+
+1. Re-issue key in provider portal.
+2. Update corresponding GitHub secret.
+3. Re-run the preflight health check.
+4. If only temporary throttling, retry later when status is `rate-limited`.

--- a/scripts/check_research_api_health.py
+++ b/scripts/check_research_api_health.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Preflight health check for research API providers.
+
+Performs lightweight, non-destructive requests against enabled providers and
+returns explicit statuses suitable for CI gating and artifact retention.
+
+Statuses:
+- missing
+- present-but-invalid
+- rate-limited
+- ok
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+
+
+@dataclass
+class ProbeResult:
+    provider: str
+    status: str
+    detail: str
+    http_status: int | None = None
+
+
+def _is_rate_limited(code: int, body: str) -> bool:
+    if code == 429:
+        return True
+    return "rate limit" in body.lower() or "too many requests" in body.lower()
+
+
+def _request(url: str, headers: dict[str, str]) -> ProbeResult:
+    req = urllib.request.Request(url, headers=headers)
+    try:
+        with urllib.request.urlopen(req, timeout=12) as resp:
+            return ProbeResult("", "ok", "request succeeded", resp.status)
+    except urllib.error.HTTPError as exc:
+        body = ""
+        try:
+            body = exc.read(512).decode("utf-8", errors="ignore")
+        except Exception:
+            pass
+        if _is_rate_limited(exc.code, body):
+            return ProbeResult("", "rate-limited", f"HTTP {exc.code}", exc.code)
+        if exc.code in (401, 403):
+            return ProbeResult("", "present-but-invalid", f"HTTP {exc.code}", exc.code)
+        return ProbeResult("", "present-but-invalid", f"HTTP {exc.code}", exc.code)
+    except Exception as exc:
+        return ProbeResult("", "present-but-invalid", str(exc), None)
+
+
+def probe_crossref() -> ProbeResult:
+    url = "https://api.crossref.org/works?rows=1&query=blue%20economy"
+    result = _request(url, {"User-Agent": "morskamary-healthcheck/1.0"})
+    result.provider = "crossref"
+    return result
+
+
+def probe_scopus() -> ProbeResult:
+    key = os.getenv("ELSEVIER_API_KEY", "") or os.getenv("SCOPUS_API_KEY", "")
+    if not key:
+        return ProbeResult("scopus", "missing", "ELSEVIER_API_KEY/SCOPUS_API_KEY not set")
+    query = urllib.parse.quote("TITLE(ocean)")
+    url = f"https://api.elsevier.com/content/search/scopus?query={query}&count=1"
+    result = _request(url, {"X-ELS-APIKey": key, "Accept": "application/json"})
+    result.provider = "scopus"
+    return result
+
+
+def probe_wos() -> ProbeResult:
+    key = os.getenv("WOS_API_KEY", "")
+    if not key:
+        return ProbeResult("wos", "missing", "WOS_API_KEY not set")
+    query = urllib.parse.quote("TS=ocean")
+    url = f"https://api.clarivate.com/apis/wos-starter/v1/documents?q={query}&limit=1&page=1"
+    result = _request(url, {"X-ApiKey": key, "Accept": "application/json"})
+    result.provider = "wos"
+    return result
+
+
+def probe_scival() -> ProbeResult:
+    key = os.getenv("SCIVAL_API_KEY", "")
+    if not key:
+        return ProbeResult("scival", "missing", "SCIVAL_API_KEY not set")
+    url = (
+        "https://api.elsevier.com/analytics/scival/author/metrics"
+        "?metricTypes=ScholarlyOutput&yearRange=5yrs&includedDocs=AllPublicationTypes"
+        "&journalImpactType=CiteScore&showAsFieldWeighted=false&byYear=false"
+        "&authors=1-s2.0-7004212771"
+    )
+    result = _request(url, {"X-ELS-APIKey": key, "Accept": "application/json"})
+    result.provider = "scival"
+    return result
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output", default="outputs/research_api_health.json")
+    parser.add_argument("--require-valid", action="store_true")
+    args = parser.parse_args()
+
+    probes = [probe_crossref, probe_scopus, probe_wos, probe_scival]
+    results = [p() for p in probes]
+
+    print("=== Research API health preflight ===")
+    for r in results:
+        code = f" (HTTP {r.http_status})" if r.http_status else ""
+        print(f"  - {r.provider:<8} {r.status:<20} {r.detail}{code}")
+
+    payload = {
+        "statuses": [r.__dict__ for r in results],
+        "summary": {"ok": sum(1 for r in results if r.status == "ok")},
+    }
+    os.makedirs(os.path.dirname(args.output), exist_ok=True)
+    with open(args.output, "w", encoding="utf-8") as f:
+        json.dump(payload, f, indent=2)
+
+    if args.require_valid:
+        invalid = [r for r in results if r.status in {"present-but-invalid", "rate-limited"}]
+        if invalid:
+            print("\nFailing preflight due to invalid/rate-limited provider credentials.")
+            return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
### Motivation
- Prevent long-running live export workflows from running with revoked, rotated, or throttled provider credentials by performing a lightweight authenticated preflight check.
- Provide machine-readable, non-secret output suitable for artifact retention and fast CI gating.

### Description
- Add `scripts/check_research_api_health.py`, a health probe that performs harmless authenticated requests and emits explicit statuses `missing`, `present-but-invalid`, `rate-limited`, and `ok` without printing secret values, and writes `outputs/research_api_health.json`.
- Gate live workflows to run the preflight with `--require-valid` and fail fast on `present-but-invalid` or `rate-limited` providers in `.github/workflows/export-research-records.yml` and `.github/workflows/research-api-smoke.yml`.
- Include the sanitized `outputs/research_api_health.json` in workflow artifacts so CI logs retain a non-secret snapshot of credential health.
- Update runbooks `docs/RESEARCH_API_CICD_SETUP.md` and `docs/ONE_CLICK_RESEARCH_RUNBOOK.md` with usage instructions, status semantics, and troubleshooting guidance for revoked/cancelled credentials.

### Testing
- Ran `python scripts/check_research_api_health.py --output outputs/research_api_health.json` which executed and produced the sanitized JSON artifact at `outputs/research_api_health.json`.
- Verified syntax with `python -m py_compile scripts/check_research_api_health.py` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f32d2a6a78832ea7659cab0888e2a7)