### PR TITLE
Add branch/PR reconciliation report with fetch diagnostics

### DIFF
--- a/branch_reconciliation_2026-04-30.md
+++ b/branch_reconciliation_2026-04-30.md
@@ -1,0 +1,29 @@
+# Branch/PR Reconciliation (generated 2026-04-30)
+
+## Remote and fetch status
+- Set `origin` to `https://github.com/robertbartlomiejski/morskamary.git`.
+- `git fetch --all --prune` failed in this environment due network restriction:
+  - `fatal: unable to access 'https://github.com/robertbartlomiejski/morskamary.git/': CONNECT tunnel failed, response 403`
+- Optional PR ref fetch (`refs/pull/*/head`) therefore also could not run successfully.
+
+## Date-bounded branch activity (since 2026-04-28)
+Data source: local refs available in clone.
+
+| branch | author | latest_commit_date | commit | ahead_behind_vs_base |
+|---|---|---|---|---|
+| work | Copilot | 2026-04-30 10:29:47 +0200 | bc3d3eb | N/A (base branch refs unavailable due fetch failure) |
+
+## PR cross-check
+Could not query open PRs from GitHub in this environment because remote/network access to GitHub failed (HTTP 403 CONNECT tunnel).
+
+### Preliminary reconciliation table
+| branch | latest_commit | has_pr | pr_number | status | action_required |
+|---|---|---:|---:|---|---|
+| work | bc3d3eb (2026-04-30) | unknown | unknown | `unverified_remote_state` | Re-run fetch/PR queries in network-enabled environment and reconcile against open PR heads |
+
+## Commands executed
+- `git remote set-url origin https://github.com/robertbartlomiejski/morskamary.git || git remote add origin https://github.com/robertbartlomiejski/morskamary.git`
+- `git fetch --all --prune`
+- `git fetch origin '+refs/pull/*/head:refs/remotes/origin/pr/*'`
+- `git branch -a`
+- `git for-each-ref --format='%(refname:short)|%(committerdate:iso8601)|%(authorname)|%(objectname:short)' refs/heads refs/remotes`

--- a/branch_reconciliation_2026-04-30.md
+++ b/branch_reconciliation_2026-04-30.md
@@ -2,7 +2,7 @@
 
 ## Remote and fetch status
 - Set `origin` to `https://github.com/robertbartlomiejski/morskamary.git`.
-- `git fetch --all --prune` failed in this environment due network restriction:
+- `git fetch --all --prune` failed in this environment due to network restrictions:
   - `fatal: unable to access 'https://github.com/robertbartlomiejski/morskamary.git/': CONNECT tunnel failed, response 403`
 - Optional PR ref fetch (`refs/pull/*/head`) therefore also could not run successfully.
 
@@ -11,7 +11,7 @@ Data source: local refs available in clone.
 
 | branch | author | latest_commit_date | commit | ahead_behind_vs_base |
 |---|---|---|---|---|
-| work | Copilot | 2026-04-30 10:29:47 +0200 | bc3d3eb | N/A (base branch refs unavailable due fetch failure) |
+| work | Copilot | 2026-04-30 10:29:47 +0200 | bc3d3eb | N/A (base branch refs unavailable due to fetch failure) |
 
 ## PR cross-check
 Could not query open PRs from GitHub in this environment because remote/network access to GitHub failed (HTTP 403 CONNECT tunnel).


### PR DESCRIPTION
### Motivation
- Provide a reproducible reconciliation report of local branches vs open PRs bounded from 2026-04-28 onward.
- Surface and document network/fetch failures that prevent authoritative cross-checks against GitHub.
- Produce a clear follow-up action list for re-running PR cross-checks in a network-enabled environment.

### Description
- Add `branch_reconciliation_2026-04-30.md` containing the remote URL normalization, fetch attempts, failure diagnostics, and a date-bounded branch activity list derived from local refs.
- Attempt to fetch full branch metadata and PR refs with `git fetch --all --prune` and `git fetch origin '+refs/pull/*/head:refs/remotes/origin/pr/*'`, and record the exact failure observed.
- Include a preliminary reconciliation table that marks branches with unknown PR status when remote verification was not possible.
- Include explicit next steps recommending re-run of fetch/PR queries in a network-enabled environment to reconcile branches and PRs.

### Testing
- Ran `git remote -v` and `git remote set-url origin https://github.com/robertbartlomiejski/morskamary.git || git remote add origin https://github.com/robertbartlomiejski/morskamary.git`, which completed and updated the `origin` URL. (success)
- Ran `git fetch --all --prune` and `git fetch origin '+refs/pull/*/head:refs/remotes/origin/pr/*'`, which failed due to network restriction with `CONNECT tunnel failed, response 403`. (failed)
- Ran `git branch -a` and `git for-each-ref --format='%(refname:short)|%(committerdate:iso8601)|%(authorname)|%(objectname:short)' refs/heads refs/remotes` to gather local ref metadata, which succeeded and produced the date-bounded branch list used in the report. (success)
- Staged and recorded the report file locally with `git add branch_reconciliation_2026-04-30.md && git commit -m "Add branch/PR reconciliation report with fetch diagnostics"`, which completed in the working clone. (success)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f32cf4cd04832e86a3e2956cfcaaea)