### PR TITLE
test: add regression for order-independent DOI/title deduplication

### DIFF
--- a/tests/test_export_live_research_records.py
+++ b/tests/test_export_live_research_records.py
@@ -118,6 +118,20 @@ class TestDeduplicateRecords:
         assert len(deduped) == 1
         assert stats["doi_duplicates"] == 2
 
+
+    def test_doi_title_dedup_is_order_independent(self):
+        """The DOI-bearing variant must win regardless of input order."""
+        title_only = _make_record(doi="", title="Blue Economy Governance")
+        with_doi = _make_record(doi="10.1234/order", title="BLUE ECONOMY: GOVERNANCE!")
+
+        first_pass, _ = deduplicate_records([title_only, with_doi])
+        second_pass, _ = deduplicate_records([with_doi, title_only])
+
+        assert len(first_pass) == 1
+        assert len(second_pass) == 1
+        assert first_pass[0].doi == "10.1234/order"
+        assert second_pass[0].doi == "10.1234/order"
+
     def test_deduplicates_later_doi_record_against_earlier_title_only_match(self):
         """
         A later DOI-bearing record with the same normalized title must not leak


### PR DESCRIPTION
### Motivation
- Ensure deduplication is order-independent so a DOI-bearing record always wins regardless of input order, addressing the P1 report about duplicates leaking when providers disagree on DOI completeness.

### Description
- Add `test_doi_title_dedup_is_order_independent` to `tests/test_export_live_research_records.py` which verifies that `deduplicate_records` retains the DOI-bearing variant whether the title-only record appears before or after it.

### Testing
- Ran `pytest -q tests/test_export_live_research_records.py -k dedup`, but test collection failed here with `ModuleNotFoundError: No module named 'yaml'` due to a missing `pyyaml` dependency; the new test is committed and should pass in an environment with project dependencies installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f327e917fc832ea50c7f843a8053e2)