### PR TITLE
Add deterministic `_detect_all_themes` with HYDRONIZATION keywords and tests

### DIFF
--- a/src/core.py
+++ b/src/core.py
@@ -23,6 +23,61 @@ class BlueDynamicsAxis(Enum):
     HYDRONIZATION = "H"  # Hydronization (water-society co-constitution and blue subjectivity)
 
 
+_AXIS_THEME_KEYWORDS: Dict[BlueDynamicsAxis, List[str]] = {
+    BlueDynamicsAxis.MARINE: [
+        "marine",
+        "ocean",
+        "fisheries",
+        "aquaculture",
+        "ecosystem",
+        "biodiversity",
+    ],
+    BlueDynamicsAxis.MARITIME: [
+        "maritime",
+        "port",
+        "shipping",
+        "logistics",
+        "infrastructure",
+        "msp",
+    ],
+    BlueDynamicsAxis.OCEANIC: [
+        "governance",
+        "policy",
+        "cooperation",
+        "justice",
+        "sustainability",
+    ],
+    BlueDynamicsAxis.HYDRONIZATION: [
+        "hydronization",
+        "hydrosocial",
+        "wet ontology",
+        "blue subjectivity",
+    ],
+}
+
+
+def _detect_all_themes(record: Dict[str, Any]) -> Dict[BlueDynamicsAxis, List[str]]:
+    """Detect per-axis thematic keywords from record text.
+
+    Returns a dictionary keyed by all QMBD axes. If no keywords are found,
+    applies a deterministic governance fallback under OCEANIC.
+    """
+    text = " ".join(
+        str(record.get(field, "")) for field in ("title", "abstract", "keywords")
+    ).lower()
+
+    themes: Dict[BlueDynamicsAxis, List[str]] = {
+        axis: [] for axis in BlueDynamicsAxis
+    }
+    for axis, keywords in _AXIS_THEME_KEYWORDS.items():
+        themes[axis] = [keyword for keyword in keywords if keyword in text]
+
+    if not any(themes.values()):
+        themes[BlueDynamicsAxis.OCEANIC] = ["[citation needed]"]
+
+    return themes
+
+
 class CompetenceLevel(Enum):
     """Competence proficiency levels"""
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -11,6 +11,7 @@ from src.core import (
     CompetenceLevel,
     create_sample_competences,
     load_competence_matrix,
+    _detect_all_themes,
 )
 from src.competence_mapper import CompetenceMapper
 
@@ -269,6 +270,43 @@ class TestCompetenceMapper:
             starting_level=CompetenceLevel.ADVANCED
         )
         assert len(pathway) == 2
+
+
+class TestDetectAllThemes:
+    """Tests for structured theme detection across all QMBD axes."""
+
+    def test_detect_all_themes_returns_all_axes(self):
+        record = {
+            "title": "Hydrosocial governance for maritime ports",
+            "abstract": "Marine ecosystems and sustainability policy",
+            "keywords": "shipping, hydronization",
+        }
+
+        themes = _detect_all_themes(record)
+
+        assert set(themes.keys()) == set(BlueDynamicsAxis)
+        assert "marine" in themes[BlueDynamicsAxis.MARINE]
+        assert "shipping" in themes[BlueDynamicsAxis.MARITIME]
+        assert "sustainability" in themes[BlueDynamicsAxis.OCEANIC]
+        assert "hydronization" in themes[BlueDynamicsAxis.HYDRONIZATION]
+
+    def test_detect_all_themes_case_insensitive(self):
+        record = {
+            "title": "HYDROSOCIAL Transitions",
+            "abstract": "PORT LOGISTICS",
+            "keywords": "MARINE",
+        }
+
+        themes = _detect_all_themes(record)
+
+        assert "hydrosocial" in themes[BlueDynamicsAxis.HYDRONIZATION]
+        assert "port" in themes[BlueDynamicsAxis.MARITIME]
+        assert "marine" in themes[BlueDynamicsAxis.MARINE]
+
+    def test_detect_all_themes_fallback_marker(self):
+        themes = _detect_all_themes({"title": "", "abstract": "", "keywords": ""})
+
+        assert themes[BlueDynamicsAxis.OCEANIC] == ["[citation needed]"]
 
 
 class TestLoadCompetenceMatrixImportError:

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -26,12 +26,14 @@ class TestBlueDynamicsAxisEnum:
         assert BlueDynamicsAxis.MARINE.value == "M"
         assert BlueDynamicsAxis.MARITIME.value == "T"
         assert BlueDynamicsAxis.OCEANIC.value == "O"
+        assert BlueDynamicsAxis.HYDRONIZATION.value == "H"
 
     def test_enum_names(self):
         """Test that enum names are correct"""
         assert BlueDynamicsAxis.MARINE.name == "MARINE"
         assert BlueDynamicsAxis.MARITIME.name == "MARITIME"
         assert BlueDynamicsAxis.OCEANIC.name == "OCEANIC"
+        assert BlueDynamicsAxis.HYDRONIZATION.name == "HYDRONIZATION"
 
     def test_enum_iteration(self):
         """Test that all axes can be iterated (QMBD — 4 axes)"""


### PR DESCRIPTION
### Motivation
- Address outstanding review gaps from the QMBD axis expansion by providing an explicit, deterministic per-axis theme detection contract. 
- Ensure the new `HYDRONIZATION` axis is discoverable by keyword-based detection without regressing existing behavior. 
- Provide a governance-first fallback when no axis keywords match to satisfy downstream consumers expecting a non-empty axis signal.

### Description
- Added `_AXIS_THEME_KEYWORDS` mapping and `src/core.py::_detect_all_themes(record) -> Dict[BlueDynamicsAxis, List[str]]` that returns a list of matched keywords for every `BlueDynamicsAxis` and emits a deterministic fallback `"[citation needed]"` under `OCEANIC` when nothing matches. 
- Implemented case-insensitive matching across `title`, `abstract`, and `keywords` fields and included explicit HYDRONIZATION keywords such as `hydronization` and `hydrosocial`. 
- Extended `tests/test_core.py` with `TestDetectAllThemes` to validate full 4-axis output shape, HYDRONIZATION detection, case-insensitive matching, and the fallback marker. 
- Updated `tests/test_edge_cases.py` to assert the `HYDRONIZATION` enum `value` and `name`, and recorded the list of changed files: `src/core.py`, `tests/test_core.py`, and `tests/test_edge_cases.py`.

### Testing
- A full `pytest -q` run in this environment errors due to missing optional dependencies (`pandas`, `yaml`) used by unrelated test suites and therefore cannot be used to validate the entire test matrix. 
- Focused test runs exercising the new detection and enum changes succeeded: targeted `tests/test_core.py` selection passed (7 passed, 21 deselected). 
- Enum/axis alignment checks in `tests/test_edge_cases.py` and `tests/test_competence_repository.py` passed (5 passed, 5 deselected).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01bb5c4d40832eacd3ba712a9cc62b)