### PR TITLE
fix: preserve src package discovery in packaging config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,11 +43,9 @@ dev = [
 "Github" = "https://github.com/robertbartlomiejski/morskamary"
 "Documentation" = "https://github.com/robertbartlomiejski/morskamary/blob/main/README.md"
 
-[tool.setuptools]
-package-dir = {"" = "src"}
-
 [tool.setuptools.packages.find]
-where = ["src"]
+where = ["."]
+include = ["src*"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
This follow-up fixes the unresolved packaging alignment raised in PR #138.

Problem
- PR #138 changed setuptools discovery to `package-dir = {"" = "src"}` with `where = ["src"]`.
- That configuration treats `src/` as the import root and can discover packages under `src/` as top-level packages.
- The repository currently imports the project package as `src`, for example `from src.core import ...`, so the installed package must continue to expose `src` as the package name.

Resolution
- Remove the `package-dir = {"" = "src"}` mapping.
- Discover packages from the repository root with `where = ["."]`.
- Restrict discovery to `include = ["src*"]` so setuptools packages the current `src` package and its subpackages.
- Keep `pytest` only in the `dev` optional dependency group; no runtime dependency change is reverted.

Expected validation
- `python -m pip install -e .[dev]`
- `python -m pytest`
- `python -c "from src.core import Competence; from src.competence_mapper import CompetenceMapper; print('ok')"`

This is the conservative alignment option recommended by the review: preserve the current import contract instead of performing a full structural migration to `src/morskamary/...`.