### PR TITLE
Follow-up: preserve first-ingested dynamic provider priority in triangulation

### DIFF
--- a/src/cumulative_analysis/triangulator.py
+++ b/src/cumulative_analysis/triangulator.py
@@ -397,9 +397,6 @@ class CumulativeTriangulator:
             if norm_doi and norm_doi in doi_to_idx:
                 idx = doi_to_idx[norm_doi]
                 old_rec = pool[idx]
-                # Preserve first-ingested dynamic provider priority.
-                if old_rec.source != ClaimOrigin.STATIC_BASELINE:
-                    continue
 
                 if _is_dynamic_record(old_rec):
                     # A previous dynamic record already claimed this work.
@@ -431,11 +428,6 @@ class CumulativeTriangulator:
             if norm_title and norm_title in title_to_idx:
                 idx = title_to_idx[norm_title]
                 old_rec = pool[idx]
-                # Preserve first-ingested dynamic provider priority.
-                if old_rec.source != ClaimOrigin.STATIC_BASELINE:
-                    continue
-                old_norm_doi = _normalize_doi(old_rec.doi) if old_rec.doi else ""
-                # Replace static slot; first dynamic variant is authoritative.
 
                 if _is_dynamic_record(old_rec):
                     # A previous dynamic record already claimed this title.

--- a/src/cumulative_analysis/triangulator.py
+++ b/src/cumulative_analysis/triangulator.py
@@ -386,6 +386,9 @@ class CumulativeTriangulator:
             if norm_doi and norm_doi in doi_to_idx:
                 idx = doi_to_idx[norm_doi]
                 old_rec = pool[idx]
+                # Preserve first-ingested dynamic provider priority.
+                if old_rec.source != ClaimOrigin.STATIC_BASELINE:
+                    continue
                 # Remove stale title-index entry so a later dynamic record
                 # matching the old static title does not overwrite this slot.
                 old_norm_title = _normalize_title(old_rec.title)
@@ -395,7 +398,7 @@ class CumulativeTriangulator:
                 ):
                     del title_to_idx[old_norm_title]
                     seen_titles.discard(old_norm_title)
-                # Replace the static slot with the dynamic (DOI-authority) rec.
+                # Replace the static slot with the first matching dynamic rec.
                 pool[idx] = dyn
                 # Register the new title so it is visible to subsequent records.
                 if norm_title and norm_title not in seen_titles:
@@ -406,7 +409,11 @@ class CumulativeTriangulator:
             # --- Title-normalised upgrade ------------------------------------
             if norm_title and norm_title in title_to_idx:
                 idx = title_to_idx[norm_title]
-                # Replace static slot; dynamic variant is authoritative.
+                old_rec = pool[idx]
+                # Preserve first-ingested dynamic provider priority.
+                if old_rec.source != ClaimOrigin.STATIC_BASELINE:
+                    continue
+                # Replace static slot; first dynamic variant is authoritative.
                 pool[idx] = dyn
                 if norm_doi:
                     doi_to_idx[norm_doi] = idx

--- a/src/cumulative_analysis/triangulator.py
+++ b/src/cumulative_analysis/triangulator.py
@@ -413,8 +413,13 @@ class CumulativeTriangulator:
                 # Preserve first-ingested dynamic provider priority.
                 if old_rec.source != ClaimOrigin.STATIC_BASELINE:
                     continue
+                old_norm_doi = _normalize_doi(old_rec.doi) if old_rec.doi else ""
                 # Replace static slot; first dynamic variant is authoritative.
                 pool[idx] = dyn
+                if old_norm_doi and old_norm_doi != norm_doi:
+                    if doi_to_idx.get(old_norm_doi) == idx:
+                        del doi_to_idx[old_norm_doi]
+                    seen_dois.discard(old_norm_doi)
                 if norm_doi:
                     doi_to_idx[norm_doi] = idx
                     seen_dois.add(norm_doi)

--- a/tests/test_cumulative_triangulator_dynamic_priority.py
+++ b/tests/test_cumulative_triangulator_dynamic_priority.py
@@ -71,3 +71,32 @@ def test_same_normalized_title_first_dynamic_provider_wins_after_static_upgrade(
 
     assert len(out) == 1
     assert out[0].provider == "Crossref"
+
+
+def test_title_upgrade_removes_old_static_doi_index(tmp_path: Path):
+    t = CumulativeTriangulator()
+    t.ingest_static_baseline(
+        _baseline_csv(tmp_path, "Shared Normalized Title", "10.1000/static-doi")
+    )
+    t.ingest_dynamic_records(
+        [
+            _record(
+                "Shared Normalized Title",
+                "10.1000/crossref-doi",
+                "Crossref",
+                "crossref:10.1000/crossref-doi",
+            ),
+            _record(
+                "A distinct Scopus record",
+                "10.1000/static-doi",
+                "Scopus",
+                "scopus:10.1000/static-doi",
+            ),
+        ]
+    )
+
+    out = t.triangulate()
+
+    assert len(out) == 2
+    providers = {rec.provider for rec in out}
+    assert providers == {"Crossref", "Scopus"}

--- a/tests/test_cumulative_triangulator_dynamic_priority.py
+++ b/tests/test_cumulative_triangulator_dynamic_priority.py
@@ -1,5 +1,10 @@
 """Regression tests for dynamic provider priority in triangulation."""
 
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
 from src.cumulative_analysis.triangulator import CumulativeTriangulator
 from src.scientific_sources.models import LiteratureRecord
 
@@ -17,8 +22,28 @@ def _record(title: str, doi: str, provider: str, source_id: str) -> LiteratureRe
     )
 
 
-def test_same_doi_first_dynamic_provider_wins():
+def _baseline_csv(tmp_path: Path, title: str, doi: str) -> Path:
+    csv_path = tmp_path / "baseline.csv"
+    with csv_path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=["title", "authors", "year", "doi", "provider", "journal", "url"])
+        writer.writeheader()
+        writer.writerow(
+            {
+                "title": title,
+                "authors": "Static Author",
+                "year": "2023",
+                "doi": doi,
+                "provider": "static",
+                "journal": "Static Journal",
+                "url": "https://example.org/static",
+            }
+        )
+    return csv_path
+
+
+def test_same_doi_first_dynamic_provider_wins_after_static_upgrade(tmp_path: Path):
     t = CumulativeTriangulator()
+    t.ingest_static_baseline(_baseline_csv(tmp_path, "Shared DOI title", "10.1000/shared"))
     t.ingest_dynamic_records(
         [
             _record("Shared DOI title", "10.1000/shared", "Crossref", "crossref:10.1000/shared"),
@@ -32,8 +57,9 @@ def test_same_doi_first_dynamic_provider_wins():
     assert out[0].provider == "Crossref"
 
 
-def test_same_normalized_title_first_dynamic_provider_wins():
+def test_same_normalized_title_first_dynamic_provider_wins_after_static_upgrade(tmp_path: Path):
     t = CumulativeTriangulator()
+    t.ingest_static_baseline(_baseline_csv(tmp_path, "Maritime Transport: Resilience", ""))
     t.ingest_dynamic_records(
         [
             _record("Maritime Transport: Resilience", "", "Crossref", "crossref:1"),

--- a/tests/test_cumulative_triangulator_dynamic_priority.py
+++ b/tests/test_cumulative_triangulator_dynamic_priority.py
@@ -1,0 +1,47 @@
+"""Regression tests for dynamic provider priority in triangulation."""
+
+from src.cumulative_analysis.triangulator import CumulativeTriangulator
+from src.scientific_sources.models import LiteratureRecord
+
+
+def _record(title: str, doi: str, provider: str, source_id: str) -> LiteratureRecord:
+    return LiteratureRecord(
+        title=title,
+        authors="A. Author",
+        year="2024",
+        doi=doi,
+        source_id=source_id,
+        provider=provider,
+        journal="Journal",
+        url="https://example.org",
+    )
+
+
+def test_same_doi_first_dynamic_provider_wins():
+    t = CumulativeTriangulator()
+    t.ingest_dynamic_records(
+        [
+            _record("Shared DOI title", "10.1000/shared", "Crossref", "crossref:10.1000/shared"),
+            _record("Shared DOI title", "10.1000/shared", "Scopus", "scopus:10.1000/shared"),
+        ]
+    )
+
+    out = t.triangulate()
+
+    assert len(out) == 1
+    assert out[0].provider == "Crossref"
+
+
+def test_same_normalized_title_first_dynamic_provider_wins():
+    t = CumulativeTriangulator()
+    t.ingest_dynamic_records(
+        [
+            _record("Maritime Transport: Resilience", "", "Crossref", "crossref:1"),
+            _record("maritime transport resilience", "", "Scopus", "scopus:1"),
+        ]
+    )
+
+    out = t.triangulate()
+
+    assert len(out) == 1
+    assert out[0].provider == "Crossref"

--- a/tests/test_cumulative_triangulator_dynamic_priority.py
+++ b/tests/test_cumulative_triangulator_dynamic_priority.py
@@ -1,4 +1,3 @@
-"""Regression tests for dynamic provider priority in triangulation."""
 """Regression tests for first-ingested dynamic priority in triangulation."""
 
 from __future__ import annotations
@@ -6,27 +5,6 @@ from __future__ import annotations
 import csv
 from pathlib import Path
 
-from src.cumulative_analysis.triangulator import CumulativeTriangulator
-from src.scientific_sources.models import LiteratureRecord
-
-
-def _record(title: str, doi: str, provider: str, source_id: str) -> LiteratureRecord:
-    return LiteratureRecord(
-        title=title,
-        authors="A. Author",
-        year="2024",
-        doi=doi,
-        source_id=source_id,
-        provider=provider,
-        journal="Journal",
-        url="https://example.org",
-    )
-
-
-def _baseline_csv(tmp_path: Path, title: str, doi: str) -> Path:
-    csv_path = tmp_path / "baseline.csv"
-    with csv_path.open("w", newline="", encoding="utf-8") as handle:
-        writer = csv.DictWriter(handle, fieldnames=["title", "authors", "year", "doi", "provider", "journal", "url"])
 from src.cumulative_analysis.triangulator import (
     ClaimOrigin,
     CumulativeTriangulator,
@@ -57,74 +35,6 @@ def _write_static_csv(tmp_path: Path, *, title: str, doi: str) -> Path:
             {
                 "title": title,
                 "authors": "Static Author",
-                "year": "2023",
-                "doi": doi,
-                "provider": "static",
-                "journal": "Static Journal",
-                "url": "https://example.org/static",
-            }
-        )
-    return csv_path
-
-
-def test_same_doi_first_dynamic_provider_wins_after_static_upgrade(tmp_path: Path):
-    t = CumulativeTriangulator()
-    t.ingest_static_baseline(_baseline_csv(tmp_path, "Shared DOI title", "10.1000/shared"))
-    t.ingest_dynamic_records(
-        [
-            _record("Shared DOI title", "10.1000/shared", "Crossref", "crossref:10.1000/shared"),
-            _record("Shared DOI title", "10.1000/shared", "Scopus", "scopus:10.1000/shared"),
-        ]
-    )
-
-    out = t.triangulate()
-
-    assert len(out) == 1
-    assert out[0].provider == "Crossref"
-
-
-def test_same_normalized_title_first_dynamic_provider_wins_after_static_upgrade(tmp_path: Path):
-    t = CumulativeTriangulator()
-    t.ingest_static_baseline(_baseline_csv(tmp_path, "Maritime Transport: Resilience", ""))
-    t.ingest_dynamic_records(
-        [
-            _record("Maritime Transport: Resilience", "", "Crossref", "crossref:1"),
-            _record("maritime transport resilience", "", "Scopus", "scopus:1"),
-        ]
-    )
-
-    out = t.triangulate()
-
-    assert len(out) == 1
-    assert out[0].provider == "Crossref"
-
-
-def test_title_upgrade_removes_old_static_doi_index(tmp_path: Path):
-    t = CumulativeTriangulator()
-    t.ingest_static_baseline(
-        _baseline_csv(tmp_path, "Shared Normalized Title", "10.1000/static-doi")
-    )
-    t.ingest_dynamic_records(
-        [
-            _record(
-                "Shared Normalized Title",
-                "10.1000/crossref-doi",
-                "Crossref",
-                "crossref:10.1000/crossref-doi",
-            ),
-            _record(
-                "A distinct Scopus record",
-                "10.1000/static-doi",
-                "Scopus",
-                "scopus:10.1000/static-doi",
-            ),
-        ]
-    )
-
-    out = t.triangulate()
-
-    assert len(out) == 2
-    providers = {rec.provider for rec in out}
                 "year": "2024",
                 "doi": doi,
                 "journal": "Static Journal",
@@ -151,7 +61,7 @@ def _record(*, provider: str, title: str, doi: str, source_id: str) -> Literatur
     )
 
 
-def test_first_dynamic_doi_match_preserved_after_static_upgrade(tmp_path):
+def test_first_dynamic_doi_match_preserved_after_static_upgrade(tmp_path: Path):
     """Later dynamic DOI duplicates must not overwrite the first dynamic upgrade."""
     doi = "10.1234/shared"
     baseline = _write_static_csv(tmp_path, title="Static Title", doi=doi)
@@ -183,7 +93,7 @@ def test_first_dynamic_doi_match_preserved_after_static_upgrade(tmp_path):
     assert result[0].source == ClaimOrigin.DYNAMIC_API_CROSSREF
 
 
-def test_first_dynamic_title_match_preserved_after_static_upgrade(tmp_path):
+def test_first_dynamic_title_match_preserved_after_static_upgrade(tmp_path: Path):
     """Later dynamic title duplicates must not overwrite the first dynamic upgrade."""
     baseline = _write_static_csv(tmp_path, title="Shared Dynamic Title", doi="")
 
@@ -214,7 +124,7 @@ def test_first_dynamic_title_match_preserved_after_static_upgrade(tmp_path):
     assert result[0].source == ClaimOrigin.DYNAMIC_API_CROSSREF
 
 
-def test_title_upgrade_removes_old_static_doi_index(tmp_path):
+def test_title_upgrade_removes_old_static_doi_index(tmp_path: Path):
     """Title-based static upgrade must clear stale DOI index for later dynamics."""
     triangulator = CumulativeTriangulator()
     triangulator.ingest_static_baseline(


### PR DESCRIPTION
### Motivation
- The `triangulate()` docstring asserts that the first dynamic record ingested should win when multiple live providers return the same DOI or the same normalized title, but the implementation allowed later dynamic records to overwrite earlier dynamic slots. 
- Preserve chronological provider priority so the first matching dynamic provider upgrades a static slot and later dynamic duplicates are skipped.

### Description
- Change `CumulativeTriangulator.triangulate()` to skip DOI-exact and title-normalised replacements when the existing slot is already dynamic, while still permitting a static baseline slot to be upgraded by the first matching dynamic record. 
- Ensure title and DOI lookup indices are kept consistent when a static slot is upgraded to dynamic. 
- Add regression tests in `tests/test_cumulative_triangulator_dynamic_priority.py` covering same-DOI and same-normalized-title scenarios (Crossref first, Scopus second → Crossref remains). 

### Testing
- Ran `pytest -q tests/test_cumulative_triangulator.py tests/test_cumulative_triangulator_dynamic_priority.py` and all tests passed. 
- Test output: `42 passed` and the new regression tests confirm first-ingested dynamic provider priority is preserved.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a021f1f4b88832e9a3203ec9e12c48b)