### PR TITLE
Add Stage 2 research metadata JSON schema and CI tests

### DIFF
--- a/MANIFEST_SOURCES.csv
+++ b/MANIFEST_SOURCES.csv
@@ -804,6 +804,7 @@ readme,other,,,,,,readme,no
 README.md,governance,,,,,,README,yes
 requirements.txt,script,,,,,,requirements,yes
 run_full_analysis.py,script,,,,,,run_full_analysis,yes
+schemas/research_metadata.schema.json,other,,,,,,research_metadata_schema,no
 scientific_bridge.py,script,,,,,,scientific_bridge,yes
 scripts/40152_2021_Article_238.PDF,script,,,,,,40152_2021_Article_238,no
 scripts/Aaa Hab 4_250621_114734.txt,script,,,,,,Aaa_Hab_4_250621_114734,yes
@@ -910,4 +911,5 @@ tests/test_run_full_analysis.py,script,,,,,,test_run_full_analysis,yes
 tests/test_scientific_bridge.py,script,,,,,,test_scientific_bridge,yes
 tests/test_scientific_sources.py,script,,,,,,test_scientific_sources,yes
 tests/test_script_cli.py,script,,,,,,test_script_cli,yes
+tests/test_stage2_schema.py,script,,,,,,test_stage2_schema,yes
 tests/test_validate_generated_outputs.py,script,,,,,,test_validate_generated_outputs,yes

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 -e .
 black==26.3.1
 flake8==7.3.0
+jsonschema==4.10.3
 mypy==1.20.2
 pytest==9.0.3

--- a/schemas/research_metadata.schema.json
+++ b/schemas/research_metadata.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://example.org/schemas/research_metadata.schema.json",
+  "$id": "https://raw.githubusercontent.com/robertbartlomiejski/morskamary/main/schemas/research_metadata.schema.json",
   "title": "Stage 2 Provider-Agnostic Research Metadata Record",
   "description": "Machine-readable governance schema for committed research metadata exports.",
   "type": "object",
@@ -30,10 +30,7 @@
       "type": "string"
     },
     "doi": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": "string"
     },
     "source_id": {
       "type": "string"
@@ -42,16 +39,10 @@
       "type": "string"
     },
     "journal": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": "string"
     },
     "url": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": "string"
     },
     "subject_terms": {
       "type": "array",
@@ -66,10 +57,7 @@
       "type": "string"
     },
     "licence_note": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": "string"
     }
   },
   "allOf": [

--- a/schemas/research_metadata.schema.json
+++ b/schemas/research_metadata.schema.json
@@ -1,0 +1,105 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.org/schemas/research_metadata.schema.json",
+  "title": "Stage 2 Provider-Agnostic Research Metadata Record",
+  "description": "Machine-readable governance schema for committed research metadata exports.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "authors",
+    "year",
+    "doi",
+    "source_id",
+    "provider",
+    "journal",
+    "url",
+    "subject_terms",
+    "source_query",
+    "retrieval_timestamp",
+    "licence_note"
+  ],
+  "properties": {
+    "title": {
+      "type": "string"
+    },
+    "authors": {
+      "type": "string"
+    },
+    "year": {
+      "type": "string"
+    },
+    "doi": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "source_id": {
+      "type": "string"
+    },
+    "provider": {
+      "type": "string"
+    },
+    "journal": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "url": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "subject_terms": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "source_query": {
+      "type": "string"
+    },
+    "retrieval_timestamp": {
+      "type": "string"
+    },
+    "licence_note": {
+      "type": [
+        "string",
+        "null"
+      ]
+    }
+  },
+  "allOf": [
+    {
+      "not": {
+        "required": [
+          "citation_count"
+        ]
+      }
+    },
+    {
+      "not": {
+        "required": [
+          "abstract_available"
+        ]
+      }
+    },
+    {
+      "not": {
+        "required": [
+          "abstract_stored"
+        ]
+      }
+    },
+    {
+      "not": {
+        "required": [
+          "abstract"
+        ]
+      }
+    }
+  ]
+}

--- a/tests/test_stage2_schema.py
+++ b/tests/test_stage2_schema.py
@@ -5,26 +5,18 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import jsonschema
+import pytest
+
 from scripts.export_live_research_records import export_records_json
 from src.scientific_sources.models import LiteratureRecord
 
-SCHEMA_PATH = Path("schemas/research_metadata.schema.json")
+SCHEMA_PATH = Path(__file__).parent.parent / "schemas" / "research_metadata.schema.json"
 
 
 def _load_schema() -> dict:
     with SCHEMA_PATH.open("r", encoding="utf-8") as f:
         return json.load(f)
-
-
-def _validate_against_stage2_schema(payload: dict, schema: dict) -> None:
-    required = set(schema["required"])
-    props = set(schema["properties"].keys())
-
-    missing = required - set(payload.keys())
-    assert not missing, f"Missing required fields: {sorted(missing)}"
-
-    extra = set(payload.keys()) - props
-    assert not extra, f"Unexpected fields (violates additionalProperties=false): {sorted(extra)}"
 
 
 def _make_record(**kwargs) -> LiteratureRecord:
@@ -66,7 +58,7 @@ def test_exported_records_conform_to_stage2_schema(tmp_path: Path):
 
     data = json.loads(out.read_text(encoding="utf-8"))
     assert isinstance(data, list) and len(data) == 1
-    _validate_against_stage2_schema(data[0], schema)
+    jsonschema.validate(instance=data[0], schema=schema)
 
 
 def test_schema_rejects_restricted_fields_in_payload():
@@ -87,10 +79,5 @@ def test_schema_rejects_restricted_fields_in_payload():
         "citation_count": 10,
     }
 
-    try:
-        _validate_against_stage2_schema(payload, schema)
-        raised = False
-    except AssertionError:
-        raised = True
-
-    assert raised, "Stage 2 schema validation must reject citation_count"
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=payload, schema=schema)

--- a/tests/test_stage2_schema.py
+++ b/tests/test_stage2_schema.py
@@ -1,0 +1,96 @@
+"""Stage 2 schema governance tests for research metadata exports."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts.export_live_research_records import export_records_json
+from src.scientific_sources.models import LiteratureRecord
+
+SCHEMA_PATH = Path("schemas/research_metadata.schema.json")
+
+
+def _load_schema() -> dict:
+    with SCHEMA_PATH.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _validate_against_stage2_schema(payload: dict, schema: dict) -> None:
+    required = set(schema["required"])
+    props = set(schema["properties"].keys())
+
+    missing = required - set(payload.keys())
+    assert not missing, f"Missing required fields: {sorted(missing)}"
+
+    extra = set(payload.keys()) - props
+    assert not extra, f"Unexpected fields (violates additionalProperties=false): {sorted(extra)}"
+
+
+def _make_record(**kwargs) -> LiteratureRecord:
+    base = dict(
+        title="Blue Economy Governance",
+        authors="Ada Lovelace",
+        year="2024",
+        doi="10.1234/blue",
+        source_id="crossref:10.1234/blue",
+        provider="crossref",
+        journal="Ocean Studies",
+        url="https://example.org/paper",
+        subject_terms=["blue economy"],
+        source_query="blue economy governance",
+        retrieval_timestamp="2026-05-12T00:00:00+00:00",
+        licence_note="open metadata",
+    )
+    base.update(kwargs)
+    return LiteratureRecord(**base)
+
+
+def test_schema_file_exists_and_blocks_restricted_fields():
+    schema = _load_schema()
+
+    assert schema["type"] == "object"
+    assert schema["additionalProperties"] is False
+    props = schema["properties"]
+    assert "citation_count" not in props
+    assert "abstract_available" not in props
+    assert "abstract_stored" not in props
+
+
+def test_exported_records_conform_to_stage2_schema(tmp_path: Path):
+    schema = _load_schema()
+    out = tmp_path / "records.json"
+
+    record = _make_record(citation_count=42, abstract_available=True, abstract_stored=True)
+    export_records_json([record], out)
+
+    data = json.loads(out.read_text(encoding="utf-8"))
+    assert isinstance(data, list) and len(data) == 1
+    _validate_against_stage2_schema(data[0], schema)
+
+
+def test_schema_rejects_restricted_fields_in_payload():
+    schema = _load_schema()
+    payload = {
+        "title": "X",
+        "authors": "Y",
+        "year": "2025",
+        "doi": "10.1/x",
+        "source_id": "crossref:10.1/x",
+        "provider": "crossref",
+        "journal": "J",
+        "url": "https://example.org",
+        "subject_terms": [],
+        "source_query": "q",
+        "retrieval_timestamp": "2026-05-12T00:00:00+00:00",
+        "licence_note": "open metadata",
+        "citation_count": 10,
+    }
+
+    try:
+        _validate_against_stage2_schema(payload, schema)
+        raised = False
+    except AssertionError:
+        raised = True
+
+    assert raised, "Stage 2 schema validation must reject citation_count"


### PR DESCRIPTION
### Motivation
- Centralize and make machine-readable the repository's Stage 1 metadata rules so exports cannot accidentally include restricted fields like `citation_count` or full abstracts. 
- Provide a provider-agnostic, schema-level guard that complements the existing `_to_stage1_compliant_dict()` filtering to reduce regression risk as new providers are added. 

### Description
- Added `schemas/research_metadata.schema.json` which defines a Stage 2 JSON Schema (draft 2020-12) that whitelists permitted bibliographic fields and sets `additionalProperties: false`. 
- The schema lists required fields (`title`, `authors`, `year`, `doi`, `source_id`, `provider`, `journal`, `url`, `subject_terms`, `source_query`, `retrieval_timestamp`, `licence_note`) and omits restricted fields; it also includes `allOf`/`not` clauses to explicitly block `citation_count` and abstract-related keys. 
- Added `tests/test_stage2_schema.py` which verifies schema integrity, asserts that `export_records_json()` output conforms to the schema, and contains a negative test confirming payloads with `citation_count` are rejected by the validation logic. 

### Testing
- Ran `pytest -q tests/test_stage2_schema.py` and all tests passed (`3 passed`). 
- The new tests exercise the schema file loading, export via `export_records_json()`, and schema-based rejection of restricted fields.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02f52f8a00832e97c25c9992e4d6ee)