### PR TITLE
#30 Fix CI workflow: use correct Codecov input for coverage upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,7 +214,7 @@ jobs:
         if: matrix.python-version == '3.11'
         uses: codecov/codecov-action@v6
         with:
-          file: ./coverage.xml
+          files: ./coverage.xml
           flags: unittests
           name: codecov-umbrella
           fail_ci_if_error: false


### PR DESCRIPTION
## Summary
This PR fixes CI configuration for Codecov upload by replacing an invalid action input key.

## What Changed
- Updated Codecov action input from `file` to `files` in `.github/workflows/ci.yml`

## Why
- The previous input key produced workflow diagnostics and could break coverage upload behavior.
- This keeps CI signal clean and deterministic.

## Validation Checklist
- [x] Change is limited to CI workflow config only
- [x] Codecov action input now matches v6 expected parameter (`files`)
- [x] No source code or test logic changed

## Risk
- Low: one-line workflow configuration fix.
