### PR TITLE
#65 Strengthen E2E credential coverage with sector-specific R&I assertion

### DIFF
--- a/tests/test_e2e_workflows.py
+++ b/tests/test_e2e_workflows.py
@@ -127,6 +127,12 @@ class TestE2EBaselineToLiteratureFlow:
         assert "baseline_1" in all_competence_ids
         assert "lit_001" in all_competence_ids or "lit_002" in all_competence_ids
 
+        ri_creds = [c for c in credentials if c.sector == "R&I"]
+        ri_competence_ids = set()
+        for cred in ri_creds:
+            ri_competence_ids.update(cred.competences)
+        assert "baseline_2" in ri_competence_ids
+
     def test_micro_credentials_generated_for_every_sector(self) -> None:
         """Ensure every declared sector receives the full EQF stack."""
         baseline = [


### PR DESCRIPTION
## Summary
This PR strengthens the E2E credential test by asserting that R&I credentials include the R&I baseline competence, not only EQF-level coverage.

## What Changed
- In `tests/test_e2e_workflows.py`, added assertion that generated credentials for sector `R&I` include `baseline_2`.

## Why
- Existing assertions verified per-sector EQF 4-7 coverage but still allowed regressions where sector-specific competences could be dropped.
- This directly addresses the open reviewer concern for PR #65.

## Validation Checklist
- [x] Targeted test updated in E2E workflow suite
- [x] New assertion verifies sector-specific competence inclusion for `R&I`
- [x] `python -m pytest tests/test_e2e_workflows.py -q` passed locally

## Risk
- Low: test-only change, no production behavior modified.
