### PR TITLE
Live export hardening: normalize providers and validate query mapping robustly

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -19,6 +19,17 @@ Entries
 Unreleased
 Use this section for changes in progress that are not yet merged into the main branch. Move items to dated entries when merged.
 
+2026-05-14
+Change type fix add
+Scope scripts tests
+Files affected scripts/export_live_research_records.py tests/test_export_live_research_records.py
+Summary Hardened live research export CLI query-file validation. yaml.safe_load() is now wrapped in a try/except yaml.YAMLError block that emits a clear parse-error message including the file path and YAML syntax detail, distinct from the structural empty/non-mapping check. Provider names are normalised (trimmed, lowercased) before registry lookup, including comma-separated inputs. Each query group's shape is validated to ensure sector_data is a dict with a non-empty list of non-empty query strings; the script exits with exit code 1 and a clear message if no runnable queries exist.
+Reason Previously a syntactically invalid YAML query file would crash the script with an unhandled traceback. Provider inputs with differing case or surrounding whitespace were silently rejected. Non-dict query-group values caused a downstream AttributeError.
+Impact scripts/export_live_research_records.py now fails fast with actionable operator messages for all YAML and provider-input edge cases.
+Provenance scripts/export_live_research_records.py (CLI entrypoint); tests/test_export_live_research_records.py (integration tests).
+Quality checks python -m pytest tests/test_export_live_research_records.py -q passed (45 tests).
+Reviewer GitHub Copilot Coding Agent
+
 2026-05-11
 Change type fix add
 Scope triangulator tests

--- a/scripts/export_live_research_records.py
+++ b/scripts/export_live_research_records.py
@@ -341,18 +341,25 @@ def main() -> int:
         return 1
 
     with open(query_file_path, "r", encoding="utf-8") as f:
-        query_config = yaml.safe_load(f)
+        query_config_raw = yaml.safe_load(f)
 
-    if not isinstance(query_config, dict):
+    if query_config_raw is None:
+        query_config: Dict[str, Any] = {}
+    elif isinstance(query_config_raw, dict):
+        query_config = query_config_raw
+    else:
         print(
-            f"Error: Query file is empty or not a valid YAML mapping: {query_file_path}",
+            f"Error: Query file is not a valid YAML mapping: {query_file_path}",
             file=sys.stderr,
         )
         return 1
 
-    query_groups = query_config.get("query_groups", {})
-    if not query_groups:
-        print("Error: No query_groups found in query file", file=sys.stderr)
+    query_groups = query_config.get("query_groups")
+    if not isinstance(query_groups, dict) or not query_groups:
+        print(
+            f"Error: No research queries found in query file: {query_file_path}",
+            file=sys.stderr,
+        )
         return 1
 
     # Initialize registry

--- a/scripts/export_live_research_records.py
+++ b/scripts/export_live_research_records.py
@@ -340,8 +340,15 @@ def main() -> int:
         print(f"Error: Query file not found: {query_file_path}", file=sys.stderr)
         return 1
 
-    with open(query_file_path, "r", encoding="utf-8") as f:
-        query_config_raw = yaml.safe_load(f)
+    try:
+        with open(query_file_path, "r", encoding="utf-8") as f:
+            query_config_raw = yaml.safe_load(f)
+    except yaml.YAMLError as exc:
+        print(
+            f"Error: Failed to parse YAML query file: {query_file_path}: {exc}",
+            file=sys.stderr,
+        )
+        return 1
 
     if query_config_raw is None:
         query_config: Dict[str, Any] = {}

--- a/scripts/export_live_research_records.py
+++ b/scripts/export_live_research_records.py
@@ -345,21 +345,19 @@ def main() -> int:
             query_config_raw = yaml.safe_load(f)
     except yaml.YAMLError as exc:
         print(
-            f"Error: Failed to parse YAML query file: {query_file_path}: {exc}",
+            f"Error: Failed to parse '{query_file_path}'. Syntactically invalid YAML:\n{exc}",
             file=sys.stderr,
         )
         return 1
 
-    if query_config_raw is None:
-        query_config: Dict[str, Any] = {}
-    elif isinstance(query_config_raw, dict):
-        query_config = query_config_raw
-    else:
+    if query_config_raw is None or not isinstance(query_config_raw, dict):
         print(
-            f"Error: Query file is not a valid YAML mapping: {query_file_path}",
+            f"Error: '{query_file_path}' is empty or not a valid YAML mapping.",
             file=sys.stderr,
         )
         return 1
+
+    query_config: Dict[str, Any] = query_config_raw
 
     query_groups = query_config.get("query_groups")
     if not isinstance(query_groups, dict) or not query_groups:

--- a/scripts/export_live_research_records.py
+++ b/scripts/export_live_research_records.py
@@ -362,6 +362,62 @@ def main() -> int:
         )
         return 1
 
+    validated_query_groups: Dict[str, Dict[str, Any]] = {}
+    runnable_query_count = 0
+    for group_name, sector_data in query_groups.items():
+        if not isinstance(sector_data, dict):
+            print(
+                "Error: Query group "
+                f"'{group_name}' must be a mapping with the shape "
+                "{label?, queries: [str, ...]}",
+                file=sys.stderr,
+            )
+            return 1
+
+        label = sector_data.get("label")
+        if label is not None and not isinstance(label, str):
+            print(
+                f"Error: Query group '{group_name}' has a non-string label",
+                file=sys.stderr,
+            )
+            return 1
+
+        queries = sector_data.get("queries")
+        if not isinstance(queries, list):
+            print(
+                f"Error: Query group '{group_name}' must define "
+                "'queries' as a non-empty list of strings",
+                file=sys.stderr,
+            )
+            return 1
+
+        normalized_queries = [
+            query.strip()
+            for query in queries
+            if isinstance(query, str) and query.strip()
+        ]
+        if len(normalized_queries) != len(queries) or not normalized_queries:
+            print(
+                f"Error: Query group '{group_name}' must define "
+                "'queries' as a non-empty list of non-empty strings",
+                file=sys.stderr,
+            )
+            return 1
+
+        validated_query_groups[group_name] = dict(sector_data)
+        validated_query_groups[group_name]["queries"] = normalized_queries
+        runnable_query_count += len(normalized_queries)
+
+    if runnable_query_count == 0:
+        print(
+            f"Error: No runnable research queries found in query file: {query_file_path}",
+            file=sys.stderr,
+        )
+        return 1
+
+    query_groups = validated_query_groups
+    query_config["query_groups"] = query_groups
+
     # Initialize registry
     registry = SourceRegistry()
 

--- a/tests/test_export_live_research_records.py
+++ b/tests/test_export_live_research_records.py
@@ -593,7 +593,7 @@ query_groups:
         result = main()
         assert result == 1
         captured = capsys.readouterr()
-        assert "No research queries found" in captured.err
+        assert "is empty or not a valid YAML mapping" in captured.err
 
     def test_comment_only_query_file_returns_error(self, tmp_path, monkeypatch, capsys):
         """A comment-only YAML file (yaml.safe_load returns None) must return error code 1."""
@@ -616,12 +616,12 @@ query_groups:
         result = main()
         assert result == 1
         captured = capsys.readouterr()
-        assert "No research queries found" in captured.err
+        assert "is empty or not a valid YAML mapping" in captured.err
 
-    def test_invalid_yaml_syntax_returns_error(self, tmp_path, monkeypatch, capsys):
+    def test_invalid_yaml_syntax_returns_parse_error(self, tmp_path, monkeypatch, capsys):
         """A YAML file with a syntax error must return error code 1 with a parse error."""
         query_file = tmp_path / "bad_syntax.yml"
-        query_file.write_text("key: [\nunot_closed\n")
+        query_file.write_text("query_groups:\n- [unclosed list\n  key: value\n")
 
         output_dir = tmp_path / "outputs"
 
@@ -639,7 +639,8 @@ query_groups:
         result = main()
         assert result == 1
         captured = capsys.readouterr()
-        assert "Failed to parse YAML query file" in captured.err
+        assert "Failed to parse" in captured.err
+        assert "Syntactically invalid YAML" in captured.err
         assert str(query_file) in captured.err
 
     def test_scalar_query_file_returns_error(self, tmp_path, monkeypatch, capsys):
@@ -663,7 +664,7 @@ query_groups:
         result = main()
         assert result == 1
         captured = capsys.readouterr()
-        assert "not a valid YAML mapping" in captured.err
+        assert "is empty or not a valid YAML mapping" in captured.err
 
     def test_zero_record_provider_identity_in_coverage(self, tmp_path, monkeypatch):
         """Zero-record provider results must preserve provider identity in coverage CSV."""

--- a/tests/test_export_live_research_records.py
+++ b/tests/test_export_live_research_records.py
@@ -593,7 +593,7 @@ query_groups:
         result = main()
         assert result == 1
         captured = capsys.readouterr()
-        assert "empty or not a valid YAML mapping" in captured.err
+        assert "No research queries found" in captured.err
 
     def test_comment_only_query_file_returns_error(self, tmp_path, monkeypatch, capsys):
         """A comment-only YAML file (yaml.safe_load returns None) must return error code 1."""
@@ -616,7 +616,7 @@ query_groups:
         result = main()
         assert result == 1
         captured = capsys.readouterr()
-        assert "empty or not a valid YAML mapping" in captured.err
+        assert "No research queries found" in captured.err
 
     def test_scalar_query_file_returns_error(self, tmp_path, monkeypatch, capsys):
         """A YAML file containing only a scalar (not a dict) must return error code 1."""
@@ -639,7 +639,7 @@ query_groups:
         result = main()
         assert result == 1
         captured = capsys.readouterr()
-        assert "empty or not a valid YAML mapping" in captured.err
+        assert "not a valid YAML mapping" in captured.err
 
     def test_zero_record_provider_identity_in_coverage(self, tmp_path, monkeypatch):
         """Zero-record provider results must preserve provider identity in coverage CSV."""
@@ -829,6 +829,7 @@ query_groups:
         mock_result = ProviderResult(records=[], provenance=[])
 
         def mock_search(query, max_results, providers):
+            assert providers == ["crossref"]
             return [mock_result]
 
         with patch(
@@ -851,6 +852,57 @@ query_groups:
                     "false",
                     "--providers",
                     "Crossref",
+                ],
+            )
+
+            result = main()
+            assert result == 0
+
+    def test_comma_separated_providers_are_trimmed_and_normalised(
+        self, tmp_path, monkeypatch
+    ):
+        """Comma-separated providers with spaces should be lowercased before search."""
+        query_file = tmp_path / "queries.yml"
+        query_file.write_text(
+            """
+query_groups:
+  test_sector:
+    label: "Test"
+    queries:
+      - "query1"
+"""
+        )
+
+        output_dir = tmp_path / "outputs"
+        mock_result_crossref = ProviderResult(records=[], provenance=[])
+        mock_result_scopus = ProviderResult(records=[], provenance=[])
+
+        def mock_search(query, max_results, providers):
+            assert providers == ["crossref", "scopus"]
+            return [mock_result_crossref, mock_result_scopus]
+
+        with patch(
+            "scripts.export_live_research_records.SourceRegistry"
+        ) as MockRegistry:
+            mock_instance = MagicMock()
+            mock_instance.search = mock_search
+            mock_instance.list_capabilities.return_value = _make_capability(
+                "crossref", "scopus"
+            )
+            MockRegistry.return_value = mock_instance
+
+            monkeypatch.setattr(
+                "sys.argv",
+                [
+                    "export_live_research_records.py",
+                    "--query-file",
+                    str(query_file),
+                    "--output-dir",
+                    str(output_dir),
+                    "--offline",
+                    "false",
+                    "--providers",
+                    " Crossref, Scopus ",
                 ],
             )
 

--- a/tests/test_export_live_research_records.py
+++ b/tests/test_export_live_research_records.py
@@ -618,6 +618,30 @@ query_groups:
         captured = capsys.readouterr()
         assert "No research queries found" in captured.err
 
+    def test_invalid_yaml_syntax_returns_error(self, tmp_path, monkeypatch, capsys):
+        """A YAML file with a syntax error must return error code 1 with a parse error."""
+        query_file = tmp_path / "bad_syntax.yml"
+        query_file.write_text("key: [\nunot_closed\n")
+
+        output_dir = tmp_path / "outputs"
+
+        monkeypatch.setattr(
+            "sys.argv",
+            [
+                "export_live_research_records.py",
+                "--query-file",
+                str(query_file),
+                "--output-dir",
+                str(output_dir),
+            ],
+        )
+
+        result = main()
+        assert result == 1
+        captured = capsys.readouterr()
+        assert "Failed to parse YAML query file" in captured.err
+        assert str(query_file) in captured.err
+
     def test_scalar_query_file_returns_error(self, tmp_path, monkeypatch, capsys):
         """A YAML file containing only a scalar (not a dict) must return error code 1."""
         query_file = tmp_path / "scalar.yml"


### PR DESCRIPTION
## Summary
This PR hardens live research export input handling to fail clearly on invalid query files and consistently normalize provider names.

## What Changed
- `scripts/export_live_research_records.py`
  - Accepts `yaml.safe_load(...) == None` as empty mapping path and emits clear error when no valid query groups exist.
  - Distinguishes invalid YAML mapping from missing/empty `query_groups`.
  - Preserves strict validation messaging for operators.
- `tests/test_export_live_research_records.py`
  - Updated expected error messages for new validation paths.
  - Added provider normalization assertions (single provider and comma-separated with spacing/case).

## Why
- Prevent silent/unclear failures for empty/comment-only query files.
- Ensure provider inputs like `Crossref` and ` Crossref, Scopus ` are normalized before registry search.

## Validation Checklist
- [x] Script behavior updated for empty/comment-only and scalar YAML edge cases
- [x] Test expectations aligned with new error messaging
- [x] Added normalization test for comma-separated providers
- [x] `python -m pytest tests/test_export_live_research_records.py -q` passed locally

## Risk
- Low/medium: controlled input-validation behavior changes plus accompanying tests.
