### PR TITLE
test: cover git worktree metadata in manifest scan

### DIFF
--- a/tests/test_generate_manifest.py
+++ b/tests/test_generate_manifest.py
@@ -256,6 +256,22 @@ class TestScanFiles:
         # Check that it's sorted
         assert rel_paths == sorted(rel_paths)
 
+    def test_scan_excludes_root_git_file_in_worktree(self, tmp_path, monkeypatch):
+        """Root .git file (Git worktree pointer) should be ignored."""
+        import scripts.generate_manifest as gm
+
+        (tmp_path / ".git").write_text("gitdir: /tmp/worktrees/repo")
+        (tmp_path / "keep.py").touch()
+
+        monkeypatch.setattr(gm, "REPO_ROOT", tmp_path)
+        monkeypatch.setattr(gm, "MANIFEST_PATH", tmp_path / "MANIFEST_SOURCES.csv")
+
+        files = gm.scan_files()
+        rel_paths = [f.relative_to(tmp_path).as_posix() for f in files]
+
+        assert ".git" not in rel_paths
+        assert "keep.py" in rel_paths
+
     def test_coverage_files_are_ignored(self):
         """Transient coverage artefacts should be ignored during scanning."""
         assert should_ignore_file(REPO_ROOT / ".coverage")


### PR DESCRIPTION
Adds regression coverage for manifest generation in Git worktrees, where the repository root contains a `.git` file rather than a `.git` directory.

Context:
- `main` already ignores `.git` file basenames in `scripts/generate_manifest.py`.
- This PR adds a focused test so that behavior stays covered.

Validation:
- `pytest -q tests/test_axis_classifier.py tests/test_run_full_analysis.py tests/test_scientific_sources.py tests/test_generate_manifest.py tests/test_export_live_research_records.py tests/test_load_real_competences.py tests/test_literature_extraction.py`
- Result: `274 passed`

Safety checks:
- No generated outputs changed.
- No local analysis outputs were reintroduced.
- No files from PR #159-#163 were deleted.