### PR TITLE
fix: remove rows_for_totals global filter; sum all acquisition_rows p…

### DIFF
--- a/src/scientific_sources/live_run_audit.py
+++ b/src/scientific_sources/live_run_audit.py
@@ -766,19 +766,18 @@ class LiveRunAuditBuilder:
                 ),
             }
 
-        rows_for_totals = [
-            row
-            for row in acquisition_rows
-            if row.query_execution_counts_applied or int(row.raw_record_count) > 0
-        ]
-
-        raw_record_total = sum(max(0, int(row.raw_record_count)) for row in rows_for_totals)
+        # Each row already carries the best available count for its (provider, query) pair:
+        # diagnostic counts when query_execution_counts_applied is True, or len(raw_bucket)
+        # otherwise.  Sum all rows directly so that diagnostic-backed queries and
+        # raw-bucket-only queries both contribute their counts without any global filter
+        # that would exclude one subset when the other is present.
+        raw_record_total = sum(max(0, int(row.raw_record_count)) for row in acquisition_rows)
         normalized_record_total = sum(
-            max(0, int(row.normalized_record_count)) for row in rows_for_totals
+            max(0, int(row.normalized_record_count)) for row in acquisition_rows
         )
         raw_records_with_normalized_descendants = sum(
             max(0, int(row.raw_record_count))
-            for row in rows_for_totals
+            for row in acquisition_rows
             if int(row.normalized_record_count) > 0
         )
 

--- a/tests/test_live_run_audit.py
+++ b/tests/test_live_run_audit.py
@@ -217,7 +217,9 @@ class TestBundleShape:
         assert manifest["run_id"] == "R1"
         assert manifest["built_at_utc"] == FROZEN_TS
         assert manifest["counts"]["raw_records"] == 7
-        assert manifest["counts"]["normalized_records"] == 3
+        # Row (Scopus, "another query only seen in evidence") has normalized_record_count=1
+        # and raw_record_count=0; per-row counting includes it, giving 2+1+1=4.
+        assert manifest["counts"]["normalized_records"] == 4
         assert manifest["counts"]["acquisition_rows"] >= 2
         assert manifest["counts"]["raw_records_with_normalized_descendants"] == 7
         # files[] excludes the manifest itself; it is listed only in


### PR DESCRIPTION
…er-row

<!--
  morskamary — Pull Request Template
  Aligned with docs/AGENT_WORKING_AGREEMENT.md § 3 (Canonical contribution contract)
-->

## Contribution declaration

<!-- Fill all five fields below. PRs with empty fields will be flagged during review. -->

### Objective
<!-- What does this PR accomplish? One sentence. -->


### Source basis
<!-- Which data, literature, or prior outputs does this change rely on? -->


### Axis logic
<!-- Which QMBD/TMBD axis (MARINE / MARITIME / OCEANIC / MULTI_AXIS) is affected and why? -->


### Expected artifact
<!-- Which output files, schemas, or capabilities change as a result? -->


### What changed, why, and which scientific aim it supports
<!-- Brief summary linking the change to a repository scientific aim. -->


---

## Sync & integration checklist

- [ ] `python scripts/sync_audit.py` passes locally (no drift detected)
- [ ] `python scripts/validate_generated_outputs.py` passes
- [ ] `python scripts/validate_research_source_outputs.py` passes
- [ ] `CHANGELOG.txt` updated for substantive tracked changes
- [ ] `MANIFEST_SOURCES.csv` regenerated and committed if data files changed
- [ ] No unresolved merge conflict markers

---

## Testing

- [ ] `python -m pytest tests/ -q` passes (all green)
- [ ] No new test failures introduced
