### PR TITLE
Web of Science: fail-closed pagination diagnostics and credential-safe error reporting

### DIFF
--- a/.github/workflows/full-live-analysis.yml
+++ b/.github/workflows/full-live-analysis.yml
@@ -328,7 +328,10 @@ jobs:
             --output outputs/release_packages/morskamary_live_cumulative_latest.zip
 
       - name: Upload live-enriched analysis outputs
-        if: always()
+        # Never upload tracked/stale audit outputs after an early preflight or
+        # acquisition failure.  Successful completion proves that this run's
+        # audit bundle and all downstream publication gates were rebuilt.
+        if: success()
         uses: actions/upload-artifact@v4
         with:
           name: live-enriched-analysis-outputs

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -19,6 +19,16 @@ Entries
 Unreleased
 Use this section for changes in progress that are not yet merged into the main branch. Move items to dated entries when merged.
 
+- 2026-07-29 (fix: fail-closed Web of Science pagination diagnostics)
+  Change type fix update
+  Scope src tests governance
+  Files affected src/scientific_sources/web_of_science.py tests/test_scientific_sources.py CHANGELOG.txt
+  Summary Corrected WoS pagination provenance so failed requests count as attempted, non-rate-limit failures populate credential-safe ProviderResult errors and explicit failed-page diagnostics, and an unconfigured provider emits no synthetic attempted-page row.
+  Reason Pagination diagnostics must distinguish provider configuration, attempted requests, successful completion, and failures without allowing a failed or unattempted acquisition to appear complete.
+  Impact Live acquisition can fail closed on WoS page failures and no longer overstates pagination attempts when WOS_API_KEY is absent. No provider request or historical output is involved.
+  Provenance config/live_query_protocol.yml sampling strategy and the Layer 1 acquisition evidence contract in .github/copilot-instructions.md.
+  Quality checks focused provider tests, canonical static analysis, generated-output validation, and archive-integrity validation.
+
 - 2026-07-25 (add: provider leave-one-out sensitivity analysis)
   Change type add update
   Scope scripts tests governance

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -19,6 +19,16 @@ Entries
 Unreleased
 Use this section for changes in progress that are not yet merged into the main branch. Move items to dated entries when merged.
 
+- 2026-07-31 (fix: restore fail-closed health and audit publication boundaries)
+  Change type fix update
+  Scope scripts workflows tests governance
+  Files affected scripts/check_research_api_health.py .github/workflows/full-live-analysis.yml tests/test_check_research_api_health.py tests/test_full_live_analysis_workflow.py CHANGELOG.txt
+  Summary Restored zero-network WoS missing-key health behavior with credential-safe transport diagnostics, and restricted live-analysis artifact upload to successful runs so an early failure cannot publish stale tracked audit outputs.
+  Reason Reviewer-protected acquisition must fail closed without persisting exception details or treating repository state from an earlier run as a current-run audit artifact.
+  Impact Health preflight retains only stable status categories, and current-run audit artifacts are uploaded only after acquisition, audit construction, and downstream gates complete successfully. No scientific results, archives, or provider data were changed.
+  Provenance Layer 1 acquisition and secret-redaction contracts in .github/copilot-instructions.md and config/live_query_protocol.yml.
+  Quality checks focused negative regressions; canonical Python, workflow, strict-sync, manifest, generated-output, and archive-contract validation.
+
 - 2026-07-29 (fix: fail-closed Web of Science pagination diagnostics)
   Change type fix update
   Scope src tests governance

--- a/scripts/check_research_api_health.py
+++ b/scripts/check_research_api_health.py
@@ -84,9 +84,11 @@ def _request(url: str, headers: dict[str, str]) -> ProbeResult:
             return ProbeResult("", "present-but-invalid", f"HTTP {exc.code}", exc.code)
         return ProbeResult("", "present-but-invalid", f"HTTP {exc.code}", exc.code)
     except Exception as exc:
+        # Exception strings can embed request URLs, headers, or provider SDK
+        # diagnostics.  Health artifacts expose only stable classifications.
         if _is_transient_network_error(exc):
-            return ProbeResult("", "transient-network-error", str(exc), None)
-        return ProbeResult("", "present-but-invalid", str(exc), None)
+            return ProbeResult("", "transient-network-error", "network failure", None)
+        return ProbeResult("", "present-but-invalid", "request failed", None)
 
 
 def probe_crossref() -> ProbeResult:
@@ -184,8 +186,10 @@ def probe_microsoft_graph() -> ProbeResult:
         return ProbeResult("microsoft_graph", "present-but-invalid", f"HTTP {exc.code}", exc.code)
     except Exception as exc:
         if _is_transient_network_error(exc):
-            return ProbeResult("microsoft_graph", "transient-network-error", str(exc))
-        return ProbeResult("microsoft_graph", "present-but-invalid", str(exc))
+            return ProbeResult(
+                "microsoft_graph", "transient-network-error", "network failure"
+            )
+        return ProbeResult("microsoft_graph", "present-but-invalid", "request failed")
 
 
 def probe_openalex() -> ProbeResult:

--- a/src/scientific_sources/web_of_science.py
+++ b/src/scientific_sources/web_of_science.py
@@ -22,11 +22,11 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import time
 import urllib.error
 import urllib.parse
 import urllib.request
 from datetime import datetime, timezone
-import time
 from typing import Any, Dict, List, Optional, Tuple, cast
 
 from src.scientific_sources.base import BaseProvider
@@ -375,11 +375,13 @@ class WebOfScienceProvider(BaseProvider):
         """
         del time_window, sort_strategy  # not used by WoS Starter
         if not self._api_key:
-            result = self._not_configured_result()
-            return result, [{"logical_page": 1, "error": "not_configured"}]
+            # No page was attempted.  Provider configuration is represented by
+            # the ProviderResult warning, not by a synthetic pagination row.
+            return self._not_configured_result(), []
 
         _WOS_MAX_LIMIT = 50
         all_records: List[LiteratureRecord] = []
+        all_errors: List[str] = []
         all_warnings: List[str] = []
         all_provenance: List[SourceEvidence] = []
         page_diagnostics: List[Dict[str, Any]] = []
@@ -399,6 +401,9 @@ class WebOfScienceProvider(BaseProvider):
                     f"{self._api_base}?q={wos_query}"
                     f"&limit={chunk_size}&page={physical_page}"
                 )
+                # Count attempted requests, including requests that fail.  This
+                # value is acquisition provenance rather than a success count.
+                physical_requests += 1
                 try:
                     payload = self._request_json(url)
                     items = payload.get("hits", [])
@@ -406,7 +411,6 @@ class WebOfScienceProvider(BaseProvider):
                         items = []
                     records = self._parse_items(items, query)
                     page_records.extend(records)
-                    physical_requests += 1
                     physical_page += 1
                     rows_remaining -= chunk_size
                     # Early stop if fewer results than requested
@@ -426,9 +430,7 @@ class WebOfScienceProvider(BaseProvider):
                             "error": "rate_limited",
                         })
                         break
-                    all_warnings.append(
-                        f"WoS page={physical_page} HTTP {exc.code}"
-                    )
+                    all_errors.append(f"WoS page={physical_page} HTTP {exc.code}")
                     page_diagnostics.append({
                         "logical_page": logical_page_idx + 1,
                         "physical_requests": physical_requests,
@@ -438,10 +440,21 @@ class WebOfScienceProvider(BaseProvider):
                         "error": f"http_{exc.code}",
                     })
                     break
-                except Exception as exc:
-                    all_warnings.append(
-                        f"WoS page={physical_page} error: {exc}"
+                except Exception:
+                    # Provider exceptions can contain request URLs or library
+                    # diagnostics.  Persist only a stable, credential-safe
+                    # category; detailed exceptions must not enter artifacts.
+                    all_errors.append(
+                        f"WoS page={physical_page} request failed"
                     )
+                    page_diagnostics.append({
+                        "logical_page": logical_page_idx + 1,
+                        "physical_requests": physical_requests,
+                        "requested_rows": rows_per_page,
+                        "returned_rows": len(page_records),
+                        "pagination_method": "wos_starter_page",
+                        "error": "request_failed",
+                    })
                     break
 
                 # Polite inter-request delay (avoid burst)
@@ -480,6 +493,7 @@ class WebOfScienceProvider(BaseProvider):
         return (
             ProviderResult(
                 records=all_records,
+                errors=all_errors,
                 warnings=all_warnings,
                 provenance=all_provenance,
                 rate_limit_status=rate_limit_status,

--- a/tests/test_check_research_api_health.py
+++ b/tests/test_check_research_api_health.py
@@ -33,7 +33,8 @@ def test_request_marks_econnreset_as_transient_network_error(reset_errno: int) -
         result = check_research_api_health._request("https://example.com", {})
 
     assert result.status == "transient-network-error"
-    assert "connection reset" in result.detail.lower()
+    assert result.detail == "network failure"
+    assert "connection reset" not in result.detail.lower()
 
 
 def test_request_keeps_other_runtime_errors_as_present_but_invalid() -> None:
@@ -42,12 +43,13 @@ def test_request_keeps_other_runtime_errors_as_present_but_invalid() -> None:
 
     with patch(
         "check_research_api_health.urllib.request.urlopen",
-        side_effect=RuntimeError("boom"),
+        side_effect=RuntimeError("credential-bearing-url?api_key=secret"),
     ):
         result = check_research_api_health._request("https://example.com", {})
 
     assert result.status == "present-but-invalid"
-    assert result.detail == "boom"
+    assert result.detail == "request failed"
+    assert "secret" not in result.detail
 
 
 def test_probe_microsoft_graph_treats_timeout_as_transient(monkeypatch) -> None:
@@ -67,7 +69,7 @@ def test_probe_microsoft_graph_treats_timeout_as_transient(monkeypatch) -> None:
 
     assert result.provider == "microsoft_graph"
     assert result.status == "transient-network-error"
-    assert "timed out" in result.detail.lower()
+    assert result.detail == "network failure"
 
 
 def test_request_success_returns_ok_status() -> None:
@@ -180,13 +182,36 @@ def test_probe_wos_and_scival_missing_keys(monkeypatch) -> None:
     monkeypatch.delenv("WOS_API_KEY", raising=False)
     monkeypatch.delenv("SCIVAL_API_KEY", raising=False)
 
-    wos_result = check_research_api_health.probe_wos()
-    scival_result = check_research_api_health.probe_scival()
+    with (
+        patch("check_research_api_health._request") as request,
+        patch("check_research_api_health.urllib.request.urlopen") as urlopen,
+    ):
+        wos_result = check_research_api_health.probe_wos()
+        scival_result = check_research_api_health.probe_scival()
 
     assert wos_result.status == "missing"
     assert wos_result.provider == "wos"
+    request.assert_not_called()
+    urlopen.assert_not_called()
     assert scival_result.status == "missing"
     assert scival_result.provider == "scival"
+
+
+def test_probe_wos_redacts_transport_failure(monkeypatch) -> None:
+    """WoS health diagnostics must not retain exception or credential details."""
+    import check_research_api_health
+
+    monkeypatch.setenv("WOS_API_KEY", "secret-wos-key")
+    with patch(
+        "check_research_api_health.urllib.request.urlopen",
+        side_effect=RuntimeError("request failed with secret-wos-key in URL"),
+    ):
+        result = check_research_api_health.probe_wos()
+
+    assert result.provider == "wos"
+    assert result.status == "present-but-invalid"
+    assert result.detail == "request failed"
+    assert "secret-wos-key" not in result.detail
 
 
 def test_probe_google_drive_missing_and_configured_paths(monkeypatch, tmp_path: Path) -> None:

--- a/tests/test_full_live_analysis_workflow.py
+++ b/tests/test_full_live_analysis_workflow.py
@@ -140,6 +140,17 @@ def test_workflow_uploads_live_runs_directory_as_artifact() -> None:
     assert "outputs/live_runs/" in upload_block
 
 
+def test_workflow_does_not_upload_stale_audit_after_early_failure() -> None:
+    """Artifact publication requires successful current-run audit generation."""
+    upload_index = WORKFLOW_TEXT.index("- name: Upload live-enriched analysis outputs")
+    upload_block = WORKFLOW_TEXT[upload_index : upload_index + 700]
+    audit_index = WORKFLOW_TEXT.index("python scripts/build_live_run_audit.py")
+
+    assert audit_index < upload_index
+    assert "if: success()" in upload_block
+    assert "if: always()" not in upload_block
+
+
 def test_commit_outputs_job_stages_live_runs_directory() -> None:
     commit_index = WORKFLOW_TEXT.index("commit-outputs:")
     commit_block = WORKFLOW_TEXT[commit_index:]

--- a/tests/test_scientific_sources.py
+++ b/tests/test_scientific_sources.py
@@ -818,14 +818,42 @@ class TestWebOfScienceProvider:
         assert len(diagnostics) == 2
 
     def test_search_paginated_not_configured(self, monkeypatch):
-        """WoS search_paginated returns not-configured when key absent."""
+        """WoS reports no attempted pages when its key is absent."""
         monkeypatch.delenv("WOS_API_KEY", raising=False)
         provider = WebOfScienceProvider()
         result, diagnostics = provider.search_paginated(
             "ocean", logical_pages=2, rows_per_page=50
         )
         assert result.is_empty
-        assert diagnostics[0].get("error") == "not_configured"
+        assert result.warnings
+        assert diagnostics == []
+
+    def test_search_paginated_failure_is_not_reported_as_complete(self, monkeypatch):
+        """A failed physical request must produce fail-closed diagnostics."""
+        monkeypatch.setenv("WOS_API_KEY", "woskey")
+        provider = WebOfScienceProvider()
+
+        def _raise_transport_error(_url):
+            raise OSError("sensitive request diagnostic")
+
+        monkeypatch.setattr(provider, "_request_json", _raise_transport_error)
+
+        result, diagnostics = provider.search_paginated(
+            "ocean", logical_pages=2, rows_per_page=50
+        )
+
+        assert result.errors == ["WoS page=1 request failed"]
+        assert "sensitive request diagnostic" not in str(result.errors)
+        assert diagnostics == [
+            {
+                "logical_page": 1,
+                "physical_requests": 1,
+                "requested_rows": 50,
+                "returned_rows": 0,
+                "pagination_method": "wos_starter_page",
+                "error": "request_failed",
+            }
+        ]
 
 
 class TestSciValProvider:

--- a/tests/test_scientific_sources.py
+++ b/tests/test_scientific_sources.py
@@ -855,6 +855,45 @@ class TestWebOfScienceProvider:
             }
         ]
 
+    def test_search_paginated_http_failure_records_attempt(self, monkeypatch):
+        """A rejected request is an attempted, failed physical request."""
+        monkeypatch.setenv("WOS_API_KEY", "woskey")
+        provider = WebOfScienceProvider()
+
+        def _raise_http_error(url):
+            raise urllib.error.HTTPError(url, 403, "forbidden", {}, None)
+
+        monkeypatch.setattr(provider, "_request_json", _raise_http_error)
+
+        result, diagnostics = provider.search_paginated(
+            "ocean", logical_pages=2, rows_per_page=50
+        )
+
+        assert result.errors == ["WoS page=1 HTTP 403"]
+        assert diagnostics[0]["physical_requests"] == 1
+        assert diagnostics[0]["error"] == "http_403"
+        assert diagnostics[0]["returned_rows"] == 0
+
+    def test_search_paginated_rate_limit_is_distinct_failure(self, monkeypatch):
+        """A 429 remains distinguishable from credentials and transport errors."""
+        monkeypatch.setenv("WOS_API_KEY", "woskey")
+        provider = WebOfScienceProvider()
+
+        def _raise_rate_limit(url):
+            raise urllib.error.HTTPError(url, 429, "rate limited", {}, None)
+
+        monkeypatch.setattr(provider, "_request_json", _raise_rate_limit)
+
+        result, diagnostics = provider.search_paginated(
+            "ocean", logical_pages=2, rows_per_page=50
+        )
+
+        assert result.errors == []
+        assert result.rate_limit_status == "rate-limited"
+        assert diagnostics[0]["physical_requests"] == 1
+        assert diagnostics[0]["error"] == "rate_limited"
+        assert len(diagnostics) == 1
+
 
 class TestSciValProvider:
     def test_not_configured_without_key(self, monkeypatch):


### PR DESCRIPTION
### Motivation
- Ensure WoS pagination provenance correctly distinguishes provider configuration, attempted requests, successful completion, and failures so a failed or unattempted acquisition cannot appear complete.
- Avoid leaking sensitive request/exception details into artifacts while still recording a stable, credential-safe failure category.

### Description
- When `WOS_API_KEY` is absent `search_paginated` now returns the provider `not_configured` `ProviderResult` and emits no synthetic pagination rows (empty diagnostics list).
- Physical request attempts are counted before each request so failed attempts are recorded as acquisition provenance in `physical_requests` regardless of success.
- Non-rate-limit HTTP failures and generic transport exceptions are recorded in `ProviderResult.errors` with sanitized messages and produce an explicit failed-page diagnostic row with `error: "request_failed"` or `http_<code>`.
- Updated tests in `tests/test_scientific_sources.py` to reflect the new behavior by changing `test_search_paginated_not_configured` expectations and adding `test_search_paginated_failure_is_not_reported_as_complete`, and updated `CHANGELOG.txt` with an entry describing the fix.

### Testing
- Ran `pytest tests/test_scientific_sources.py -q` and the updated WoS pagination tests passed.
- Static import/layout change (moved `time` import) was validated by running the same test module without import errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a69b8e7b3d8832ead2217e21fc11842)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Web of Science pagination diagnostics for failed requests.
  * Failed pages are now counted as attempted, with clearer HTTP and rate-limit classifications.
  * Transport errors now provide safe, structured messages without exposing sensitive details.
  * Unconfigured Web of Science searches no longer show misleading pagination entries.
  * Health checks now redact network and request error details.
  * Live-analysis artifacts are uploaded only after successful analysis completion, preventing stale or incomplete artifacts from being published.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->