### PR TITLE
feat: add fail-closed research question accountability registry

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -19,6 +19,15 @@ Entries
 Unreleased
 Use this section for changes in progress that are not yet merged into the main branch. Move items to dated entries when merged.
 
+- 2026-08-09 (add: fail-closed research-question registry and accountability contract)
+  Change type add update
+  Scope config schemas src scripts tests governance
+  Files affected config/research_question_registry.yml schemas/research_question_registry.schema.json schemas/research_question_accountability.schema.json src/scientific_sources/research_question_registry.py scripts/validate_research_question_registry.py tests/test_research_question_registry.py CHANGELOG.txt MANIFEST_SOURCES.csv
+  Summary Adds the maintainer-approved RQ1-RQ8, RQ4.1-RQ4.4 and ETQ1-ETQ7 wording as a proposed_for_review machine-readable registry with explicit populations, observational units, variables, indicators, measures, denominators, missing/excluded handling, evidence boundaries, method readiness, interpretation limits and honest logical-view materialization status. Adds typed schema and semantic validation for canonical QMBD axes, protocol-only H1-H3 references, independent EQF 6-7 supply restrictions for H2, and complete future accountability ledgers that retain unresolved outcomes rather than manufacturing answers.
+  Reason Research questions previously lacked an executable accountability and operationalisation contract, allowing omitted questions, invalid parent or axis links, planned methods to appear implemented, unmaterialized views to appear resolved, protocol hypothesis drift, incomplete ledgers and unsupported answered states.
+  Impact No empirical output, provider acquisition, occurrence identity, gap result, credential supply or publication package is changed. The registry remains proposed_for_review; all target views are logical_unmaterialized and review_required, ETQs remain not_operationalised or not_collected, generated credentials/pathways remain design candidates, and H2 remains not_computable without independently validated EQF 6-7 supply.
+  Provenance Maintainer-supplied research agenda dated 2026-08-09 for question wording; config/live_query_protocol.yml for authoritative H1-H3 declarations; docs/AGENT_WORKING_AGREEMENT.md, docs/STATISTICAL_ANALYSIS_PLAN.md, schema-v2 cumulative database contracts and outputs/cumulative_database/VARIABLE_LABELS.csv for repository governance and analytical conventions.
+  Quality checks Focused registry/accountability suite passed (27 tests); full pytest passed (1604 passed, 2 expected skips); full flake8 and mypy passed; the registry CLI, generated-output validator and immutable run-archive validator passed; research-source validation passed with one informational missing-smoke-report warning; sync audit passed with only the expected pre-commit dirty-tree warning; changelog enforcement, deterministic manifest regeneration and independent code review passed. No provider calls, live run or output regeneration were performed.
 - 2026-08-09 (fix: preserve OpenAlex protocol sort and sanitize archive/static reproducibility contracts)
   Change type fix update
   Scope scripts src tests docs workflows outputs governance

--- a/MANIFEST_SOURCES.csv
+++ b/MANIFEST_SOURCES.csv
@@ -45,6 +45,7 @@ compose.yaml,other,,,,,,compose,no
 config/live_query_protocol.yml,other,,,,,,live_query_protocol,no
 config/research_provider_policy.yml,other,,,,,,research_provider_policy,no
 config/research_queries.yml,other,,,,,,research_queries,no
+config/research_question_registry.yml,other,,,,,,research_question_registry,no
 config/research_sources.example.yml,other,,,,,,research_sources_example,no
 CONTRIBUTING.md,text,,,,,,CONTRIBUTING,yes
 COPILOT_MCP_SETUP.md,text,,,,,,COPILOT_MCP_SETUP,yes
@@ -1166,6 +1167,8 @@ schemas/qmbd_gold_review_set.schema.json,other,,,,,,qmbd_gold_review_set_schema,
 schemas/reliability_metrics.schema.json,other,,,,,,reliability_metrics_schema,yes
 schemas/research_data_package_manifest.schema.json,other,,,,,,research_data_package_manifest_schema,yes
 schemas/research_metadata.schema.json,other,,,,,,research_metadata_schema,yes
+schemas/research_question_accountability.schema.json,other,,,,,,research_question_accountability_schema,yes
+schemas/research_question_registry.schema.json,other,,,,,,research_question_registry_schema,yes
 schemas/run_archive_manifest.schema.json,other,,,,,,run_archive_manifest_schema,yes
 schemas/runs.schema.json,other,,,,,,runs_schema,yes
 schemas/sector_competence_assignments.schema.json,other,,,,,,sector_competence_assignments_schema,yes
@@ -1238,6 +1241,7 @@ scripts/Tripatle Blue Value Model WOW.txt,script,,,,,,Tripatle_Blue_Value_Model_
 scripts/validate_csv_bundle.py,script,,,,,,validate_csv_bundle,yes
 scripts/validate_generated_outputs.py,script,,,,,,validate_generated_outputs,yes
 scripts/validate_manual_sources_gatekeeper.py,script,,,,,,validate_manual_sources_gatekeeper,yes
+scripts/validate_research_question_registry.py,script,,,,,,validate_research_question_registry,yes
 scripts/validate_research_source_outputs.py,script,,,,,,validate_research_source_outputs,yes
 scripts/validate_run_archive_integrity.py,script,,,,,,validate_run_archive_integrity,yes
 scripts/Wyrzucone przez morze_250521_002507.txt,script,,,,,,Wyrzucone_przez_morze_250521_002507,yes
@@ -1273,6 +1277,7 @@ src/scientific_sources/microsoft_graph.py,script,,,,,,microsoft_graph,yes
 src/scientific_sources/models.py,script,,,,,,models,yes
 src/scientific_sources/openalex.py,script,,,,,,openalex,yes
 src/scientific_sources/provenance.py,script,,,,,,provenance,yes
+src/scientific_sources/research_question_registry.py,script,,,,,,research_question_registry,yes
 src/scientific_sources/schema_v2_identity.py,script,,,,,,schema_v2_identity,yes
 src/scientific_sources/scival.py,script,,,,,,scival,yes
 src/scientific_sources/source_registry.py,script,,,,,,source_registry,yes
@@ -1343,6 +1348,7 @@ tests/test_provider_sensitivity.py,script,,,,,,test_provider_sensitivity,yes
 tests/test_provider_sensitivity_analysis.py,script,,,,,,test_provider_sensitivity_analysis,yes
 tests/test_publication_cumulative_database.py,script,,,,,,test_publication_cumulative_database,yes
 tests/test_research_queries_config.py,script,,,,,,test_research_queries_config,yes
+tests/test_research_question_registry.py,script,,,,,,test_research_question_registry,yes
 tests/test_research_support_scripts.py,script,,,,,,test_research_support_scripts,yes
 tests/test_revalidate_historical_outputs.py,script,,,,,,test_revalidate_historical_outputs,yes
 tests/test_run_full_analysis.py,script,,,,,,test_run_full_analysis,yes

--- a/config/research_question_registry.yml
+++ b/config/research_question_registry.yml
@@ -1,0 +1,746 @@
+registry_version: 1.0.0
+status: proposed_for_review
+authority:
+  hypotheses: config/live_query_protocol.yml
+  questions: maintainer-supplied_research_agenda_2026-08-09
+canonical_axes:
+  - canonical_name: MARINE
+    display_code: M
+    meaning: biophysical, ecological and more-than-human agency or constraints
+  - canonical_name: MARITIME
+    display_code: T
+    meaning: labour, technology, infrastructure, economy and institutional mediation
+  - canonical_name: OCEANIC
+    display_code: O
+    meaning: planetary coupling, transboundary governance and hydrosocial responsibility
+  - canonical_name: HYDRONIZATION
+    display_code: H
+    meaning: water-mediated transformation, hydro-social relations and translation across terrestrial and aquatic systems
+allowed_result_statuses:
+  - answered
+  - partially_answered
+  - not_computable
+  - not_operationalised
+  - not_collected
+  - review_required
+required_accountability_fields:
+  - question_id
+  - result_status
+  - view_kind
+  - scientific_status
+  - observational_unit
+  - n
+  - missing_n
+  - denominator
+  - method
+  - evidence_references
+  - validity_threats
+  - permitted_interpretation
+  - prohibited_interpretation
+hypothesis_reference:
+  authoritative_source: config/live_query_protocol.yml
+  ordered_ids: [H1, H2, H3]
+  definition_policy: Definitions and tests are loaded only from the authoritative protocol and are not duplicated in this registry.
+  h2_supply_rule:
+    minimum_eqf_levels: [6, 7]
+    required_supply_status: independently_validated
+    generated_designs_are_supply: false
+    default_without_supply: not_computable
+
+questions:
+  - id: RQ1
+    item_type: research_question
+    text: What detailed competences does the Blue Economy demand across the four QMBD axes and 12 Blue Economy sectors?
+    status: operationalised_with_validation_limit
+    construct: reviewed competence demand
+    population_definition: Accepted canonical competences assigned to an eligible Blue Economy sector and canonical QMBD axis within a declared analysis snapshot.
+    target_view: vw_canonical_competence
+    view_kind: logical_canonical_view
+    observational_unit: validated canonical competence assignment
+    variables:
+      - canonical_competence_id
+      - validation_status
+      - sector
+      - axis_group
+      - axis_code
+    indicators:
+      - accepted canonical competence assignments by sector and axis
+      - distinct accepted canonical competences within each sector and axis
+    measures:
+      - count
+      - percentage
+      - sector_by_axis_crosstab
+    denominator: All eligible accepted canonical competence assignments in the declared analysis population; distinct-competence measures must state their separate denominator.
+    missing_handling: Retain missing sector or axis assignments as missing and report missing_n; do not impute an axis from query text or source_query.
+    excluded_handling: Exclude rejected, superseded, candidate-only and review-required competence records from validated-demand counts and report excluded_n.
+    evidence_boundary: Positive demand evidence requires legally retained title, subject terms, abstract or full text linked through reviewed provenance; query text and source_query are provenance only.
+    methods:
+      - name: count
+        readiness: conditional
+        approval_status: review_required
+        prerequisite: Materialize the canonical competence view from accepted validation decisions and freeze the analysis snapshot.
+      - name: percentage
+        readiness: conditional
+        approval_status: review_required
+        prerequisite: Approve assignment and distinct-competence denominators.
+      - name: sector_by_axis_crosstab
+        readiness: planned
+        approval_status: review_required
+        prerequisite: Materialize validated sector-axis assignments without mixing analytical grains.
+    permitted_interpretation: Descriptive distribution of reviewed competence demand within the declared retained-evidence population after the logical view is materialized and validated.
+    prohibited_interpretation: Legacy labels or semantic signals alone must not be reported as validated competences, and observed distributions must not be generalized to the entire Blue Economy.
+    materialization:
+      status: logical_unmaterialized
+      readiness: review_required
+      artifact_path: ""
+    repository_source_basis:
+      - config/live_query_protocol.yml
+      - docs/STATISTICAL_ANALYSIS_PLAN.md
+      - src/scientific_sources/cumulative_scientific_database.py
+
+  - id: RQ2
+    item_type: research_question
+    text: What unique skills does the Blue Economy demand across the four QMBD axes and 12 Blue Economy sectors?
+    status: requires_construct_definition_and_review
+    construct: unique reviewed skill
+    population_definition: Candidate subset of accepted canonical competences that can be classified as skills after a uniqueness rule and review protocol are approved.
+    target_view: vw_canonical_competence
+    view_kind: logical_canonical_view
+    observational_unit: validated canonical skill construct
+    variables:
+      - canonical_competence_id
+      - preferred_label
+      - skill_dimension
+      - sector
+      - axis_group
+    indicators:
+      - reviewed skill classification
+      - reviewed uniqueness decision under an approved comparison rule
+    measures:
+      - count
+      - frequency
+      - mode
+    denominator: Not approved until the skill construct, comparison universe and uniqueness rule are registered.
+    missing_handling: Report unclassified skill_dimension and unresolved uniqueness decisions as missing_n; do not derive uniqueness from keyword rarity.
+    excluded_handling: Exclude generated learning outcomes, unmatched keywords and unreviewed candidates from observed-skill counts and report excluded_n.
+    evidence_boundary: Skill evidence must retain reviewed canonical identity and exact evidence provenance; generated learning outcomes and query text are not observations of unique skills.
+    methods:
+      - name: count
+        readiness: planned
+        approval_status: review_required
+        prerequisite: Approve the skill construct and uniqueness decision rule.
+      - name: frequency
+        readiness: planned
+        approval_status: review_required
+        prerequisite: Define the comparison population and repeated-label treatment.
+      - name: mode
+        readiness: planned
+        approval_status: review_required
+        prerequisite: Establish a valid categorical skill variable with reviewed values.
+    permitted_interpretation: Exploratory inventory of reviewed skills after construct and uniqueness approval, limited to the declared evidence population.
+    prohibited_interpretation: Generated learning outcomes, unique keywords or low-frequency labels must not be presented as observed unique skills.
+    materialization:
+      status: logical_unmaterialized
+      readiness: review_required
+      artifact_path: ""
+    repository_source_basis:
+      - docs/STATISTICAL_ANALYSIS_PLAN.md
+      - src/scientific_sources/cumulative_scientific_database.py
+
+  - id: RQ3
+    item_type: research_question
+    text: What sector gaps are communicated across the four QMBD axes and 12 Blue Economy sectors?
+    status: conditionally_computable
+    construct: validated uncovered canonical demand
+    population_definition: Accepted canonical demand assignments for which independently validated supply coverage can be evaluated at a declared sector, axis and qualification scope.
+    target_view: vw_validated_supply
+    view_kind: logical_supply_view
+    observational_unit: accepted canonical demand identity
+    variables:
+      - canonical_competence_id
+      - sector
+      - axis_group
+      - validated_supply_status
+      - validated_supply_eqf_level
+    indicators:
+      - accepted demand with independently validated matching supply
+      - accepted demand without independently validated matching supply
+    measures:
+      - count
+      - percentage
+      - uncovered_demand_ratio
+    denominator: All eligible accepted canonical demand identities for which the independently validated supply registry has completed matching at the declared scope.
+    missing_handling: Unresolved supply matching is missing, not uncovered; report missing_n and do not convert it to a gap.
+    excluded_handling: Exclude generated credential designs, candidate pathways, static undercoverage proxies and unvalidated supply records; report excluded_n.
+    evidence_boundary: Gap evidence requires accepted demand plus an independent validated-supply assessment; source_query, baseline undercoverage and generated designs cannot establish a gap.
+    methods:
+      - name: count
+        readiness: conditional
+        approval_status: review_required
+        prerequisite: Materialize an independently validated demand-supply matching view.
+      - name: percentage
+        readiness: conditional
+        approval_status: review_required
+        prerequisite: Complete supply matching for the declared denominator.
+    permitted_interpretation: Descriptive uncovered-demand estimates within a completely assessed, independently validated supply scope.
+    prohibited_interpretation: Baseline undercoverage or generated credentials must not be called a validated sector gap.
+    materialization:
+      status: logical_unmaterialized
+      readiness: review_required
+      artifact_path: ""
+    repository_source_basis:
+      - config/live_query_protocol.yml
+      - docs/STATISTICAL_ANALYSIS_PLAN.md
+      - src/scientific_sources/derived_competence_analysis.py
+
+  - id: RQ4
+    item_type: research_question
+    text: How are the 12 Blue Economy sectors distributed across cumulative competences and QMBD axes?
+    status: operationalised_at_multiple_grains
+    construct: sector by QMBD distribution
+    population_definition: Accepted sector-to-canonical-competence assignments in a fixed cumulative analysis snapshot, with assignment and distinct-competence grains reported separately.
+    target_view: vw_sector_competence_assignment
+    view_kind: logical_assignment_view
+    observational_unit: sector by validated canonical competence assignment
+    variables:
+      - assignment_id
+      - canonical_competence_id
+      - sector
+      - axis_group
+      - axis_code
+    indicators:
+      - accepted assignments by sector and axis
+      - distinct canonical competences by sector and axis
+    measures:
+      - crosstab
+      - row_percentage
+      - column_percentage
+      - cramers_v
+    denominator: Assignment-level totals for assignment distributions and distinct canonical-competence totals for competence distributions, reported separately.
+    missing_handling: Retain missing sector or canonical axis assignments as missing_n and exclude them from axis-specific percentages only with an explicit denominator note.
+    excluded_handling: Exclude rejected, superseded, candidate-only and review-required assignments from validated distributions and report excluded_n.
+    evidence_boundary: Distribution inputs require accepted canonical competences and accepted sector-axis assignments linked to retained evidence; fragments and semantic signals remain upstream evidence, not analytical units.
+    methods:
+      - name: crosstab
+        readiness: conditional
+        approval_status: review_required
+        prerequisite: Materialize one declared grain at a time from accepted assignments.
+      - name: row_percentage
+        readiness: conditional
+        approval_status: review_required
+        prerequisite: Approve row denominators and missing-value treatment.
+      - name: column_percentage
+        readiness: conditional
+        approval_status: review_required
+        prerequisite: Approve column denominators and missing-value treatment.
+      - name: cramers_v
+        readiness: planned
+        approval_status: review_required
+        prerequisite: Confirm independent observational units and adequate expected cell counts.
+    permitted_interpretation: Descriptive association between sectors and canonical axes at an explicitly declared analytical grain.
+    prohibited_interpretation: Records, fragments, signals, competences and assignments must not be mixed in one denominator, and association must not be described as causation.
+    materialization:
+      status: logical_unmaterialized
+      readiness: review_required
+      artifact_path: ""
+    repository_source_basis:
+      - docs/STATISTICAL_ANALYSIS_PLAN.md
+      - src/scientific_sources/cumulative_scientific_database.py
+
+  - id: RQ4.1
+    item_type: research_question
+    parent_id: RQ4
+    text: What is the sector cross-table for the MARINE axis?
+    status: operationalised_at_multiple_grains
+    axis_name: MARINE
+    axis_code: M
+    construct: sector distribution within the MARINE axis
+    population_definition: Accepted MARINE sector-to-canonical-competence assignments in a fixed cumulative analysis snapshot.
+    target_view: vw_sector_competence_assignment
+    view_kind: logical_assignment_view
+    observational_unit: sector by validated canonical competence assignment
+    variables:
+      - assignment_id
+      - canonical_competence_id
+      - sector
+      - axis_group
+      - axis_code
+    indicators:
+      - accepted MARINE assignments by sector
+      - distinct MARINE canonical competences by sector
+    measures:
+      - count
+      - row_percentage
+      - column_percentage
+    denominator: Eligible accepted assignments with axis_name MARINE and axis_code M; distinct-competence summaries must use a separately stated denominator.
+    missing_handling: Missing axes remain missing and cannot be assigned to MARINE from query provenance.
+    excluded_handling: Exclude non-MARINE, rejected, superseded, candidate-only and review-required assignments and report excluded_n by reason.
+    evidence_boundary: MARINE membership requires the canonical MARINE/M assignment pair on accepted reviewed evidence.
+    methods:
+      - name: count
+        readiness: conditional
+        approval_status: review_required
+        prerequisite: Materialize accepted MARINE/M assignments.
+      - name: row_percentage
+        readiness: conditional
+        approval_status: review_required
+        prerequisite: Approve sector-row denominators.
+      - name: column_percentage
+        readiness: conditional
+        approval_status: review_required
+        prerequisite: Approve MARINE-column denominators.
+    permitted_interpretation: Descriptive sector distribution of reviewed MARINE/M assignments at the declared grain.
+    prohibited_interpretation: Sentence-level signals or query targeting must not be silently promoted to MARINE canonical competences.
+    materialization:
+      status: logical_unmaterialized
+      readiness: review_required
+      artifact_path: ""
+    repository_source_basis:
+      - docs/STATISTICAL_ANALYSIS_PLAN.md
+      - src/scientific_sources/cumulative_scientific_database.py
+
+  - id: RQ4.2
+    item_type: research_question
+    parent_id: RQ4
+    text: What is the sector cross-table for the MARITIME axis?
+    status: operationalised_at_multiple_grains
+    axis_name: MARITIME
+    axis_code: T
+    construct: sector distribution within the MARITIME axis
+    population_definition: Accepted MARITIME sector-to-canonical-competence assignments in a fixed cumulative analysis snapshot.
+    target_view: vw_sector_competence_assignment
+    view_kind: logical_assignment_view
+    observational_unit: sector by validated canonical competence assignment
+    variables:
+      - assignment_id
+      - canonical_competence_id
+      - sector
+      - axis_group
+      - axis_code
+    indicators:
+      - accepted MARITIME assignments by sector
+      - distinct MARITIME canonical competences by sector
+    measures:
+      - count
+      - row_percentage
+      - column_percentage
+    denominator: Eligible accepted assignments with axis_name MARITIME and axis_code T; distinct-competence summaries must use a separately stated denominator.
+    missing_handling: Missing axes remain missing and cannot be assigned to MARITIME from query provenance.
+    excluded_handling: Exclude non-MARITIME, rejected, superseded, candidate-only and review-required assignments and report excluded_n by reason.
+    evidence_boundary: MARITIME membership requires the canonical MARITIME/T assignment pair on accepted reviewed evidence.
+    methods:
+      - name: count
+        readiness: conditional
+        approval_status: review_required
+        prerequisite: Materialize accepted MARITIME/T assignments.
+      - name: row_percentage
+        readiness: conditional
+        approval_status: review_required
+        prerequisite: Approve sector-row denominators.
+      - name: column_percentage
+        readiness: conditional
+        approval_status: review_required
+        prerequisite: Approve MARITIME-column denominators.
+    permitted_interpretation: Descriptive sector distribution of reviewed MARITIME/T assignments at the declared grain.
+    prohibited_interpretation: Sentence-level signals or query targeting must not be silently promoted to MARITIME canonical competences.
+    materialization:
+      status: logical_unmaterialized
+      readiness: review_required
+      artifact_path: ""
+    repository_source_basis:
+      - docs/STATISTICAL_ANALYSIS_PLAN.md
+      - src/scientific_sources/cumulative_scientific_database.py
+
+  - id: RQ4.3
+    item_type: research_question
+    parent_id: RQ4
+    text: What is the sector cross-table for the OCEANIC axis?
+    status: operationalised_at_multiple_grains
+    axis_name: OCEANIC
+    axis_code: O
+    construct: sector distribution within the OCEANIC axis
+    population_definition: Accepted OCEANIC sector-to-canonical-competence assignments in a fixed cumulative analysis snapshot.
+    target_view: vw_sector_competence_assignment
+    view_kind: logical_assignment_view
+    observational_unit: sector by validated canonical competence assignment
+    variables:
+      - assignment_id
+      - canonical_competence_id
+      - sector
+      - axis_group
+      - axis_code
+    indicators:
+      - accepted OCEANIC assignments by sector
+      - distinct OCEANIC canonical competences by sector
+    measures:
+      - count
+      - row_percentage
+      - column_percentage
+    denominator: Eligible accepted assignments with axis_name OCEANIC and axis_code O; distinct-competence summaries must use a separately stated denominator.
+    missing_handling: Missing axes remain missing and cannot be assigned to OCEANIC from query provenance.
+    excluded_handling: Exclude non-OCEANIC, rejected, superseded, candidate-only and review-required assignments and report excluded_n by reason.
+    evidence_boundary: OCEANIC membership requires the canonical OCEANIC/O assignment pair on accepted reviewed evidence.
+    methods:
+      - name: count
+        readiness: conditional
+        approval_status: review_required
+        prerequisite: Materialize accepted OCEANIC/O assignments.
+      - name: row_percentage
+        readiness: conditional
+        approval_status: review_required
+        prerequisite: Approve sector-row denominators.
+      - name: column_percentage
+        readiness: conditional
+        approval_status: review_required
+        prerequisite: Approve OCEANIC-column denominators.
+    permitted_interpretation: Descriptive sector distribution of reviewed OCEANIC/O assignments at the declared grain.
+    prohibited_interpretation: Sentence-level signals or query targeting must not be silently promoted to OCEANIC canonical competences.
+    materialization:
+      status: logical_unmaterialized
+      readiness: review_required
+      artifact_path: ""
+    repository_source_basis:
+      - docs/STATISTICAL_ANALYSIS_PLAN.md
+      - src/scientific_sources/cumulative_scientific_database.py
+
+  - id: RQ4.4
+    item_type: research_question
+    parent_id: RQ4
+    text: What is the sector cross-table for the HYDRONIZATION axis?
+    status: operationalised_at_multiple_grains
+    axis_name: HYDRONIZATION
+    axis_code: H
+    construct: sector distribution within the HYDRONIZATION axis
+    population_definition: Accepted HYDRONIZATION sector-to-canonical-competence assignments in a fixed cumulative analysis snapshot.
+    target_view: vw_sector_competence_assignment
+    view_kind: logical_assignment_view
+    observational_unit: sector by validated canonical competence assignment
+    variables:
+      - assignment_id
+      - canonical_competence_id
+      - sector
+      - axis_group
+      - axis_code
+    indicators:
+      - accepted HYDRONIZATION assignments by sector
+      - distinct HYDRONIZATION canonical competences by sector
+    measures:
+      - count
+      - row_percentage
+      - column_percentage
+    denominator: Eligible accepted assignments with axis_name HYDRONIZATION and axis_code H; distinct-competence summaries must use a separately stated denominator.
+    missing_handling: Missing axes remain missing and cannot be assigned to HYDRONIZATION from query provenance.
+    excluded_handling: Exclude non-HYDRONIZATION, rejected, superseded, candidate-only and review-required assignments and report excluded_n by reason.
+    evidence_boundary: HYDRONIZATION membership requires the canonical HYDRONIZATION/H assignment pair on accepted reviewed evidence.
+    methods:
+      - name: count
+        readiness: conditional
+        approval_status: review_required
+        prerequisite: Materialize accepted HYDRONIZATION/H assignments.
+      - name: row_percentage
+        readiness: conditional
+        approval_status: review_required
+        prerequisite: Approve sector-row denominators.
+      - name: column_percentage
+        readiness: conditional
+        approval_status: review_required
+        prerequisite: Approve HYDRONIZATION-column denominators.
+    permitted_interpretation: Descriptive sector distribution of reviewed HYDRONIZATION/H assignments at the declared grain.
+    prohibited_interpretation: Sentence-level signals must not be silently promoted to canonical competences, and generated credentials cannot establish HYDRONIZATION supply.
+    materialization:
+      status: logical_unmaterialized
+      readiness: review_required
+      artifact_path: ""
+    repository_source_basis:
+      - config/live_query_protocol.yml
+      - docs/STATISTICAL_ANALYSIS_PLAN.md
+      - src/scientific_sources/cumulative_scientific_database.py
+
+  - id: RQ5
+    item_type: research_question
+    text: What is the taxonomy of competences and skills needed to accelerate the Blue Economy?
+    status: requires_reviewed_taxonomy
+    construct: reviewed competence and skill taxonomy
+    population_definition: Accepted canonical competences and reviewed skill constructs eligible for classification under a preregistered taxonomy protocol.
+    target_view: vw_canonical_competence
+    view_kind: logical_canonical_view
+    observational_unit: validated canonical construct
+    variables:
+      - canonical_competence_id
+      - preferred_label
+      - canonical_definition
+      - knowledge_dimension
+      - skill_dimension
+      - responsibility_autonomy_dimension
+    indicators:
+      - reviewed taxonomy membership
+      - reviewed hierarchical relation
+      - classification stability where estimable
+    measures:
+      - frequency
+      - modal_category
+      - hierarchical_or_factor_method_if_valid
+    denominator: All eligible accepted canonical constructs included by the approved taxonomy protocol.
+    missing_handling: Report constructs without an approved taxonomy assignment as missing_n; do not auto-fill from classifier clusters.
+    excluded_handling: Exclude rejected, superseded and review-required candidates and report excluded_n.
+    evidence_boundary: Taxonomy membership requires reviewed canonical constructs and an approved classification decision; classifier output is exploratory evidence only.
+    methods:
+      - name: frequency
+        readiness: planned
+        approval_status: review_required
+        prerequisite: Approve taxonomy categories and membership decisions.
+      - name: modal_category
+        readiness: planned
+        approval_status: review_required
+        prerequisite: Materialize a reviewed categorical taxonomy assignment.
+      - name: hierarchical_or_factor_method_if_valid
+        readiness: planned
+        approval_status: review_required
+        prerequisite: Preregister the method and establish adequate sample size, measurement level and stability diagnostics.
+    permitted_interpretation: Reviewed descriptive taxonomy within the declared canonical-construct population after taxonomy validation.
+    prohibited_interpretation: A classifier cluster is exploratory and must not be presented as a validated taxonomy.
+    materialization:
+      status: logical_unmaterialized
+      readiness: review_required
+      artifact_path: ""
+    repository_source_basis:
+      - docs/STATISTICAL_ANALYSIS_PLAN.md
+      - src/scientific_sources/cumulative_scientific_database.py
+
+  - id: RQ6
+    item_type: research_question
+    text: What is the taxonomy of structural competence and skill gaps constraining Blue Economy demands?
+    status: conditionally_computable
+    construct: reviewed taxonomy of validated uncovered demand
+    population_definition: Validated uncovered canonical demand identities after complete independent supply matching and approved gap-taxonomy review.
+    target_view: vw_validated_supply
+    view_kind: logical_supply_view
+    observational_unit: validated uncovered canonical demand
+    variables:
+      - canonical_competence_id
+      - sector
+      - axis_group
+      - validated_supply_status
+      - reviewed_gap_taxonomy_category
+    indicators:
+      - validated uncovered demand
+      - reviewed structural-gap taxonomy membership
+      - cluster stability if an exploratory clustering method is approved
+    measures:
+      - frequency
+      - percentage
+      - cluster_stability
+    denominator: All eligible validated uncovered canonical demand identities after complete matching within the declared independent supply scope.
+    missing_handling: Unresolved supply matches or taxonomy assignments are missing and must not be coded as structural gaps.
+    excluded_handling: Exclude generated credentials, candidate pathways, incomplete supply assessments and unreviewed clusters; report excluded_n.
+    evidence_boundary: Structural-gap evidence requires accepted demand, independent validated-supply assessment and reviewed taxonomy assignment.
+    methods:
+      - name: frequency
+        readiness: conditional
+        approval_status: review_required
+        prerequisite: Complete validated supply matching and approve taxonomy categories.
+      - name: percentage
+        readiness: conditional
+        approval_status: review_required
+        prerequisite: Establish a complete eligible denominator.
+      - name: cluster_stability
+        readiness: planned
+        approval_status: review_required
+        prerequisite: Preregister clustering inputs, population, selection rule and stability thresholds.
+    permitted_interpretation: Descriptive taxonomy of reviewed uncovered demand within a complete declared validation scope.
+    prohibited_interpretation: A four-cluster solution is not validated until population, stability and external supply readiness are reported.
+    materialization:
+      status: logical_unmaterialized
+      readiness: review_required
+      artifact_path: ""
+    repository_source_basis:
+      - config/live_query_protocol.yml
+      - docs/STATISTICAL_ANALYSIS_PLAN.md
+      - src/scientific_sources/derived_competence_analysis.py
+
+  - id: RQ7
+    item_type: research_question
+    text: What micro-credential pathways across the 12 sectors are proposed to address identified competence gaps?
+    status: design_output_only
+    construct: credential-design pathway candidate
+    population_definition: Generated credential-design candidates and directed pathway relations explicitly labelled candidate or review_required.
+    target_view: vw_credential_design_candidate
+    view_kind: logical_design_view
+    observational_unit: credential-design candidate or directed pathway
+    variables:
+      - credential_id
+      - credential_status
+      - review_required
+      - sector
+      - axis_group
+      - pathway_source_id
+      - pathway_target_id
+    indicators:
+      - design candidates by sector and axis
+      - proposed directed pathway relations
+    measures:
+      - count
+      - frequency
+      - network_descriptive
+    denominator: All generated design candidates or all eligible directed pathway relations in the declared design snapshot, reported separately.
+    missing_handling: Missing sector, axis or pathway endpoints remain missing and must not be inferred as validated coverage.
+    excluded_handling: Exclude malformed or superseded designs from descriptive candidate counts and report excluded_n; never reclassify candidates as validated supply.
+    evidence_boundary: These are design proposals derived from prior analytical inputs and are not empirical observations of credential availability, effectiveness or uptake.
+    methods:
+      - name: count
+        readiness: conditional
+        approval_status: review_required
+        prerequisite: Materialize a versioned candidate-design view with candidate status preserved.
+      - name: frequency
+        readiness: conditional
+        approval_status: review_required
+        prerequisite: Approve design-candidate categories and denominator.
+      - name: network_descriptive
+        readiness: planned
+        approval_status: review_required
+        prerequisite: Validate directed pathway endpoints and network grain.
+    permitted_interpretation: Descriptive account of proposed, review-required credential designs and pathway relations.
+    prohibited_interpretation: Necessary pathways, effectiveness, learner outcomes, real provision and validated supply coverage cannot be inferred from generated designs.
+    materialization:
+      status: logical_unmaterialized
+      readiness: review_required
+      artifact_path: ""
+    repository_source_basis:
+      - docs/STATISTICAL_ANALYSIS_PLAN.md
+      - schemas/dynamic_credentials.schema.json
+      - src/scientific_sources/derived_competence_analysis.py
+
+  - id: RQ8
+    item_type: research_question
+    text: How do competence-demand and validated-credential distributions align with or challenge H1, H2 and H3?
+    status: conditionally_computable
+    construct: hypothesis-specific distributions
+    population_definition: Hypothesis-specific eligible observations and declared outcomes loaded from the authoritative protocol, with each hypothesis reported independently.
+    target_view: hypothesis_result
+    view_kind: logical_hypothesis_result_set
+    observational_unit: hypothesis-specific result
+    variables:
+      - hypothesis_id
+      - declared_outcome
+      - required_result_fields
+      - eligible_evidence_count
+      - validated_supply_status
+    indicators:
+      - protocol-declared hypothesis result
+      - hypothesis-specific sample size and effect or coverage measure
+      - explicit not_computable status when prerequisites fail
+    measures:
+      - declared_hypothesis_test
+      - effect_size_if_valid
+      - uncertainty_if_valid
+    denominator: The hypothesis-specific eligible population declared by the authoritative protocol and method implementation; denominators must be reported independently for H1, H2 and H3.
+    missing_handling: Missing required inputs produce not_computable with warnings; no hypothesis may be omitted or inferred from another hypothesis.
+    excluded_handling: Exclude query-only signals, unreviewed candidates and generated credential designs from empirical hypothesis inputs; report excluded_n.
+    evidence_boundary: H1-H3 definitions, tests, axes, outcomes and required fields come only from config/live_query_protocol.yml; retained evidence and independently validated supply must satisfy each declared method.
+    methods:
+      - name: declared_hypothesis_test
+        readiness: conditional
+        approval_status: review_required
+        prerequisite: Load every authoritative hypothesis declaration and satisfy its required inputs.
+      - name: effect_size_if_valid
+        readiness: conditional
+        approval_status: review_required
+        prerequisite: Use only the effect measure declared for the hypothesis and report its eligible sample.
+      - name: uncertainty_if_valid
+        readiness: planned
+        approval_status: review_required
+        prerequisite: Preregister an uncertainty method appropriate to the hypothesis-specific observational unit.
+    permitted_interpretation: Hypothesis-specific support, partial support, non-support or non-computability within the declared retained-evidence and validation boundaries.
+    prohibited_interpretation: H2 cannot be computed from generated credentials; historical legacy results cannot be upgraded to canonical evidence, and an absent result cannot be treated as support.
+    materialization:
+      status: logical_unmaterialized
+      readiness: review_required
+      artifact_path: ""
+    repository_source_basis:
+      - config/live_query_protocol.yml
+      - docs/STATISTICAL_ANALYSIS_PLAN.md
+      - src/scientific_sources/derived_competence_analysis.py
+
+extended_questions:
+  - id: ETQ1
+    item_type: extended_question
+    text: How do structural competence gaps across the 12 sectors reveal a systemic deficit in sociological, ethical and governance skills?
+    status: not_operationalised
+    prerequisites:
+      - Define and validate the sociological, ethical and governance construct registry and external supply denominator.
+    permitted_interpretation: No empirical interpretation is permitted before the construct registry and denominator are approved.
+    prohibited_interpretation: Existing gap labels must not be reinterpreted as evidence of a systemic sociological, ethical or governance deficit.
+    repository_source_basis:
+      - docs/AGENT_WORKING_AGREEMENT.md
+      - docs/STATISTICAL_ANALYSIS_PLAN.md
+  - id: ETQ2
+    item_type: extended_question
+    text: What reviewed relations connect evidence authors, publishers and source scope to baselines, validated credentials, EQF levels, target groups, sectors, axes, dictionaries, competences and gaps?
+    status: not_operationalised
+    prerequisites:
+      - Build normalized typed link tables with provenance, cardinality and validation status; exclude generated supply from validated links.
+    permitted_interpretation: No relational result is permitted until typed link tables and validation states are registered.
+    prohibited_interpretation: Co-occurrence, shared labels or generated designs must not be reported as reviewed relations.
+    repository_source_basis:
+      - docs/AGENT_WORKING_AGREEMENT.md
+      - src/scientific_sources/cumulative_scientific_database.py
+  - id: ETQ3
+    item_type: extended_question
+    text: How does QMBD translate Blue Economy and Blue Sustainability from political ideology toward socio-technical reality?
+    status: not_operationalised
+    prerequisites:
+      - Predeclare observable translation mechanisms, comparison cases and reviewed indicators.
+    permitted_interpretation: No translation claim is permitted before mechanisms, cases and indicators are approved.
+    prohibited_interpretation: Retrieval terms or theoretical language must not be treated as observed socio-technical transformation.
+    repository_source_basis:
+      - config/live_query_protocol.yml
+      - docs/AGENT_WORKING_AGREEMENT.md
+  - id: ETQ4
+    item_type: extended_question
+    text: What is the performativity of the World Ocean in competence demand, educational deficits, courses, EQF mappings, credentials and dictionaries?
+    status: not_operationalised
+    prerequisites:
+      - Operationalise actant, mediation, translation, performed change and retained textual evidence without treating rhetoric as effect.
+    permitted_interpretation: No performativity result is permitted until the actant and performed-change constructs are operationalised.
+    prohibited_interpretation: Rhetorical reference to the World Ocean must not be reported as an observed performative effect.
+    repository_source_basis:
+      - config/live_query_protocol.yml
+      - docs/AGENT_WORKING_AGREEMENT.md
+  - id: ETQ5
+    item_type: extended_question
+    text: What is the performativity of the Blue Economy in competence demand, educational deficits, courses, EQF mappings, credentials and dictionaries?
+    status: not_operationalised
+    prerequisites:
+      - Distinguish discourse manifestation from observed institutional or labour-market effects.
+    permitted_interpretation: No performativity result is permitted until discourse and observed effects have separate operational definitions.
+    prohibited_interpretation: Blue Economy discourse frequency must not be reported as institutional or labour-market effect.
+    repository_source_basis:
+      - config/live_query_protocol.yml
+      - docs/AGENT_WORKING_AGREEMENT.md
+  - id: ETQ6
+    item_type: extended_question
+    text: How are Blue Economy demands mediated across credentials, competences, gaps, courses and EQF through marinization, maritimization, oceanization and hydronization across sectors, domains and realms?
+    status: not_operationalised
+    prerequisites:
+      - Approve a finite codebook and typed multi-level network; use association rather than causal impact language for observational text data.
+    permitted_interpretation: No mediation result is permitted before the finite codebook and typed network are approved.
+    prohibited_interpretation: Observational text associations must not be described as causal mediation or impact.
+    repository_source_basis:
+      - config/live_query_protocol.yml
+      - docs/AGENT_WORKING_AGREEMENT.md
+  - id: ETQ7
+    item_type: extended_question
+    text: How do FAIR and CARE principles in maritime data governance protect local and Indigenous knowledge during Marine Spatial Planning?
+    status: not_collected
+    prerequisites:
+      - Add an approved protocol, governance indicators and appropriately governed evidence corpus before analysis.
+    permitted_interpretation: No protection outcome is permitted until appropriately governed evidence is collected under an approved protocol.
+    prohibited_interpretation: Repository governance intentions must not be reported as observed protection of local or Indigenous knowledge.
+    repository_source_basis:
+      - docs/AGENT_WORKING_AGREEMENT.md
+
+unregistered_agenda:
+  lisbon_fieldwork_vignette_hypotheses:
+    count_reported_by_maintainer: 4
+    status: wording_required
+    rule: Do not infer or operationalise until exact statements, population, measures and governance approval are supplied.

--- a/schemas/research_question_accountability.schema.json
+++ b/schemas/research_question_accountability.schema.json
@@ -1,0 +1,248 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://morskamary.local/schemas/research_question_accountability.schema.json",
+  "title": "Research question accountability ledger",
+  "description": "Complete question-level accountability ledger. Non-results and review states are retained rather than omitted.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["ledger_version", "entries"],
+  "properties": {
+    "ledger_version": {
+      "type": "string",
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+    },
+    "entries": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/accountabilityEntry"
+      }
+    }
+  },
+  "$defs": {
+    "nonEmptyString": {
+      "type": "string",
+      "minLength": 1
+    },
+    "nullableCount": {
+      "type": ["integer", "null"],
+      "minimum": 0
+    },
+    "accountabilityEntry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "question_id",
+        "item_type",
+        "result_status",
+        "view_kind",
+        "scientific_status",
+        "observational_unit",
+        "population_definition",
+        "n",
+        "missing_n",
+        "excluded_n",
+        "denominator",
+        "method",
+        "method_readiness",
+        "evidence_references",
+        "validity_threats",
+        "permitted_interpretation",
+        "prohibited_interpretation",
+        "registry_version",
+        "registry_fingerprint",
+        "protocol_version",
+        "protocol_fingerprint",
+        "identity_schema_version",
+        "classifier_version",
+        "analysis_timestamp",
+        "warnings"
+      ],
+      "properties": {
+        "question_id": {
+          "type": "string",
+          "pattern": "^(?:RQ(?:[1-9][0-9]*)(?:\\.[1-9][0-9]*)?|ETQ[1-9][0-9]*)$"
+        },
+        "item_type": {
+          "type": "string",
+          "enum": ["research_question", "extended_question"]
+        },
+        "result_status": {
+          "type": "string",
+          "enum": [
+            "answered",
+            "partially_answered",
+            "not_computable",
+            "not_operationalised",
+            "not_collected",
+            "review_required"
+          ]
+        },
+        "view_kind": {
+          "type": "string",
+          "enum": [
+            "logical_canonical_view",
+            "logical_assignment_view",
+            "logical_supply_view",
+            "logical_design_view",
+            "logical_hypothesis_result_set",
+            "not_defined"
+          ]
+        },
+        "scientific_status": {
+          "type": "string",
+          "enum": [
+            "answer_established",
+            "answer_not_established",
+            "computation_blocked",
+            "operationalisation_required",
+            "collection_not_started",
+            "review_required"
+          ]
+        },
+        "observational_unit": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "population_definition": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "n": {
+          "$ref": "#/$defs/nullableCount"
+        },
+        "missing_n": {
+          "$ref": "#/$defs/nullableCount"
+        },
+        "excluded_n": {
+          "$ref": "#/$defs/nullableCount"
+        },
+        "denominator": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "method": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "method_readiness": {
+          "type": "string",
+          "enum": ["implemented", "planned", "conditional", "not_applicable"]
+        },
+        "evidence_references": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/nonEmptyString"
+          },
+          "uniqueItems": true
+        },
+        "validity_threats": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/nonEmptyString"
+          },
+          "uniqueItems": true
+        },
+        "permitted_interpretation": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "prohibited_interpretation": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "registry_version": {
+          "type": "string",
+          "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+        },
+        "registry_fingerprint": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "protocol_version": {
+          "type": "string",
+          "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+        },
+        "protocol_fingerprint": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "identity_schema_version": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "classifier_version": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "analysis_timestamp": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "warnings": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/nonEmptyString"
+          },
+          "uniqueItems": true
+        },
+        "hypothesis_results": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/hypothesisResult"
+          }
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "question_id": {
+                "const": "RQ8"
+              }
+            },
+            "required": ["question_id"]
+          },
+          "then": {
+            "required": ["hypothesis_results"]
+          }
+        }
+      ]
+    },
+    "hypothesisResult": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "hypothesis_id",
+        "outcome",
+        "validated_supply_status",
+        "evidence_references",
+        "warnings"
+      ],
+      "properties": {
+        "hypothesis_id": {
+          "type": "string",
+          "pattern": "^H[0-9]+$"
+        },
+        "outcome": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "validated_supply_status": {
+          "type": "string",
+          "enum": [
+            "independently_validated",
+            "not_available",
+            "not_applicable"
+          ]
+        },
+        "evidence_references": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/nonEmptyString"
+          },
+          "uniqueItems": true
+        },
+        "warnings": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/nonEmptyString"
+          },
+          "uniqueItems": true
+        }
+      }
+    }
+  }
+}

--- a/schemas/research_question_registry.schema.json
+++ b/schemas/research_question_registry.schema.json
@@ -1,0 +1,459 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://morskamary.local/schemas/research_question_registry.schema.json",
+  "title": "Research question registry",
+  "description": "Fail-closed Layer 0 registry for proposed research questions and their operationalisation.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "registry_version",
+    "status",
+    "authority",
+    "canonical_axes",
+    "allowed_result_statuses",
+    "required_accountability_fields",
+    "hypothesis_reference",
+    "questions",
+    "extended_questions",
+    "unregistered_agenda"
+  ],
+  "properties": {
+    "registry_version": {
+      "type": "string",
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+    },
+    "status": {
+      "const": "proposed_for_review"
+    },
+    "authority": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["hypotheses", "questions"],
+      "properties": {
+        "hypotheses": {
+          "const": "config/live_query_protocol.yml"
+        },
+        "questions": {
+          "const": "maintainer-supplied_research_agenda_2026-08-09"
+        }
+      }
+    },
+    "canonical_axes": {
+      "type": "array",
+      "minItems": 4,
+      "maxItems": 4,
+      "items": {
+        "$ref": "#/$defs/axisIdentity"
+      }
+    },
+    "allowed_result_statuses": {
+      "type": "array",
+      "minItems": 6,
+      "items": {
+        "$ref": "#/$defs/resultStatus"
+      },
+      "uniqueItems": true
+    },
+    "required_accountability_fields": {
+      "type": "array",
+      "minItems": 13,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "uniqueItems": true
+    },
+    "hypothesis_reference": {
+      "$ref": "#/$defs/hypothesisReference"
+    },
+    "questions": {
+      "type": "array",
+      "minItems": 12,
+      "maxItems": 12,
+      "items": {
+        "$ref": "#/$defs/researchQuestion"
+      }
+    },
+    "extended_questions": {
+      "type": "array",
+      "minItems": 7,
+      "maxItems": 7,
+      "items": {
+        "$ref": "#/$defs/extendedQuestion"
+      }
+    },
+    "unregistered_agenda": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["lisbon_fieldwork_vignette_hypotheses"],
+      "properties": {
+        "lisbon_fieldwork_vignette_hypotheses": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["count_reported_by_maintainer", "status", "rule"],
+          "properties": {
+            "count_reported_by_maintainer": {
+              "const": 4
+            },
+            "status": {
+              "const": "wording_required"
+            },
+            "rule": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "nonEmptyString": {
+      "type": "string",
+      "minLength": 1
+    },
+    "repositoryPath": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^(?![A-Za-z]:)(?!/)(?!\\\\).+"
+    },
+    "stringList": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/nonEmptyString"
+      },
+      "uniqueItems": true
+    },
+    "axisName": {
+      "type": "string",
+      "enum": ["MARINE", "MARITIME", "OCEANIC", "HYDRONIZATION"]
+    },
+    "axisCode": {
+      "type": "string",
+      "enum": ["M", "T", "O", "H"]
+    },
+    "axisIdentity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["canonical_name", "display_code", "meaning"],
+      "properties": {
+        "canonical_name": {
+          "$ref": "#/$defs/axisName"
+        },
+        "display_code": {
+          "$ref": "#/$defs/axisCode"
+        },
+        "meaning": {
+          "$ref": "#/$defs/nonEmptyString"
+        }
+      }
+    },
+    "resultStatus": {
+      "type": "string",
+      "enum": [
+        "answered",
+        "partially_answered",
+        "not_computable",
+        "not_operationalised",
+        "not_collected",
+        "review_required"
+      ]
+    },
+    "hypothesisReference": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "authoritative_source",
+        "ordered_ids",
+        "definition_policy",
+        "h2_supply_rule"
+      ],
+      "properties": {
+        "authoritative_source": {
+          "const": "config/live_query_protocol.yml"
+        },
+        "ordered_ids": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "pattern": "^H[0-9]+$"
+          },
+          "uniqueItems": true
+        },
+        "definition_policy": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "h2_supply_rule": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "minimum_eqf_levels",
+            "required_supply_status",
+            "generated_designs_are_supply",
+            "default_without_supply"
+          ],
+          "properties": {
+            "minimum_eqf_levels": {
+              "const": [6, 7]
+            },
+            "required_supply_status": {
+              "const": "independently_validated"
+            },
+            "generated_designs_are_supply": {
+              "const": false
+            },
+            "default_without_supply": {
+              "const": "not_computable"
+            }
+          }
+        }
+      }
+    },
+    "method": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "readiness",
+        "approval_status",
+        "prerequisite"
+      ],
+      "properties": {
+        "name": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "readiness": {
+          "type": "string",
+          "enum": ["implemented", "planned", "conditional"]
+        },
+        "approval_status": {
+          "type": "string",
+          "enum": ["repository_approved", "review_required"]
+        },
+        "prerequisite": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "implementation_reference": {
+          "$ref": "#/$defs/repositoryPath"
+        }
+      }
+    },
+    "materialization": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "readiness", "artifact_path"],
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": ["logical_unmaterialized", "materialized"]
+        },
+        "readiness": {
+          "type": "string",
+          "enum": ["review_required", "conditional", "ready"]
+        },
+        "artifact_path": {
+          "type": "string"
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "status": {
+                "const": "materialized"
+              }
+            },
+            "required": ["status"]
+          },
+          "then": {
+            "properties": {
+              "artifact_path": {
+                "$ref": "#/$defs/repositoryPath"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "researchQuestion": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "item_type",
+        "text",
+        "status",
+        "construct",
+        "population_definition",
+        "target_view",
+        "view_kind",
+        "observational_unit",
+        "variables",
+        "indicators",
+        "measures",
+        "denominator",
+        "missing_handling",
+        "excluded_handling",
+        "evidence_boundary",
+        "methods",
+        "permitted_interpretation",
+        "prohibited_interpretation",
+        "materialization",
+        "repository_source_basis"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^RQ(?:[1-9][0-9]*)(?:\\.[1-9][0-9]*)?$"
+        },
+        "item_type": {
+          "const": "research_question"
+        },
+        "parent_id": {
+          "type": "string",
+          "pattern": "^RQ(?:[1-9][0-9]*)$"
+        },
+        "text": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "operationalised_with_validation_limit",
+            "requires_construct_definition_and_review",
+            "conditionally_computable",
+            "operationalised_at_multiple_grains",
+            "requires_reviewed_taxonomy",
+            "design_output_only"
+          ]
+        },
+        "axis_name": {
+          "$ref": "#/$defs/axisName"
+        },
+        "axis_code": {
+          "$ref": "#/$defs/axisCode"
+        },
+        "construct": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "population_definition": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "target_view": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "view_kind": {
+          "type": "string",
+          "enum": [
+            "logical_canonical_view",
+            "logical_assignment_view",
+            "logical_supply_view",
+            "logical_design_view",
+            "logical_hypothesis_result_set"
+          ]
+        },
+        "observational_unit": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "variables": {
+          "$ref": "#/$defs/stringList"
+        },
+        "indicators": {
+          "$ref": "#/$defs/stringList"
+        },
+        "measures": {
+          "$ref": "#/$defs/stringList"
+        },
+        "denominator": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "missing_handling": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "excluded_handling": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "evidence_boundary": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "methods": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/method"
+          }
+        },
+        "permitted_interpretation": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "prohibited_interpretation": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "materialization": {
+          "$ref": "#/$defs/materialization"
+        },
+        "repository_source_basis": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/repositoryPath"
+          },
+          "uniqueItems": true
+        }
+      },
+      "dependentRequired": {
+        "axis_name": ["axis_code"],
+        "axis_code": ["axis_name"]
+      }
+    },
+    "extendedQuestion": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "item_type",
+        "text",
+        "status",
+        "prerequisites",
+        "permitted_interpretation",
+        "prohibited_interpretation",
+        "repository_source_basis"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^ETQ[1-9][0-9]*$"
+        },
+        "item_type": {
+          "const": "extended_question"
+        },
+        "text": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "status": {
+          "type": "string",
+          "enum": ["not_operationalised", "not_collected"]
+        },
+        "prerequisites": {
+          "$ref": "#/$defs/stringList"
+        },
+        "permitted_interpretation": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "prohibited_interpretation": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "repository_source_basis": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/repositoryPath"
+          },
+          "uniqueItems": true
+        }
+      }
+    }
+  }
+}

--- a/scripts/validate_research_question_registry.py
+++ b/scripts/validate_research_question_registry.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Validate the research-question registry and an optional accountability ledger."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from src.scientific_sources.research_question_registry import (  # noqa: E402
+    DEFAULT_ACCOUNTABILITY_SCHEMA_PATH,
+    DEFAULT_PROTOCOL_PATH,
+    DEFAULT_REGISTRY_PATH,
+    DEFAULT_REGISTRY_SCHEMA_PATH,
+    ResearchQuestionRegistryError,
+    load_accountability_ledger,
+    load_research_question_registry,
+)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse CLI arguments."""
+
+    parser = argparse.ArgumentParser(
+        description=(
+            "Fail closed on invalid research-question registries and incomplete "
+            "accountability ledgers."
+        )
+    )
+    parser.add_argument("--registry", type=Path, default=DEFAULT_REGISTRY_PATH)
+    parser.add_argument("--protocol", type=Path, default=DEFAULT_PROTOCOL_PATH)
+    parser.add_argument(
+        "--registry-schema",
+        type=Path,
+        default=DEFAULT_REGISTRY_SCHEMA_PATH,
+    )
+    parser.add_argument(
+        "--accountability",
+        type=Path,
+        help="Optional YAML or JSON accountability ledger to validate.",
+    )
+    parser.add_argument(
+        "--accountability-schema",
+        type=Path,
+        default=DEFAULT_ACCOUNTABILITY_SCHEMA_PATH,
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run registry and optional ledger validation."""
+
+    args = parse_args(argv)
+    try:
+        registry = load_research_question_registry(
+            args.registry,
+            protocol_path=args.protocol,
+            schema_path=args.registry_schema,
+        )
+        print(
+            "[OK] Research-question registry valid: "
+            f"{len(registry.questions)} RQs, "
+            f"{len(registry.extended_questions)} ETQs, "
+            f"{len(registry.protocol.ordered_hypothesis_ids)} protocol hypotheses"
+        )
+        if args.accountability is not None:
+            ledger = load_accountability_ledger(
+                args.accountability,
+                registry,
+                schema_path=args.accountability_schema,
+            )
+            print(
+                "[OK] Research-question accountability ledger valid: "
+                f"{len(ledger.entries)} complete entries"
+            )
+    except ResearchQuestionRegistryError as exc:
+        print(f"[ERROR] {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/src/scientific_sources/research_question_registry.py
+++ b/src/scientific_sources/research_question_registry.py
@@ -1,0 +1,943 @@
+"""Typed, fail-closed research-question and accountability-ledger validation."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping, Sequence, Tuple, cast
+
+import yaml  # type: ignore[import-untyped]
+from jsonschema import Draft202012Validator, FormatChecker
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_REGISTRY_PATH = REPO_ROOT / "config" / "research_question_registry.yml"
+DEFAULT_PROTOCOL_PATH = REPO_ROOT / "config" / "live_query_protocol.yml"
+DEFAULT_REGISTRY_SCHEMA_PATH = (
+    REPO_ROOT / "schemas" / "research_question_registry.schema.json"
+)
+DEFAULT_ACCOUNTABILITY_SCHEMA_PATH = (
+    REPO_ROOT / "schemas" / "research_question_accountability.schema.json"
+)
+
+CANONICAL_AXES: Tuple[Tuple[str, str], ...] = (
+    ("MARINE", "M"),
+    ("MARITIME", "T"),
+    ("OCEANIC", "O"),
+    ("HYDRONIZATION", "H"),
+)
+REQUIRED_QUESTION_IDS: Tuple[str, ...] = (
+    "RQ1",
+    "RQ2",
+    "RQ3",
+    "RQ4",
+    "RQ4.1",
+    "RQ4.2",
+    "RQ4.3",
+    "RQ4.4",
+    "RQ5",
+    "RQ6",
+    "RQ7",
+    "RQ8",
+)
+REQUIRED_EXTENDED_QUESTION_IDS: Tuple[str, ...] = (
+    "ETQ1",
+    "ETQ2",
+    "ETQ3",
+    "ETQ4",
+    "ETQ5",
+    "ETQ6",
+    "ETQ7",
+)
+RQ4_AXIS_CONTRACT: Mapping[str, Tuple[str, str]] = {
+    "RQ4.1": ("MARINE", "M"),
+    "RQ4.2": ("MARITIME", "T"),
+    "RQ4.3": ("OCEANIC", "O"),
+    "RQ4.4": ("HYDRONIZATION", "H"),
+}
+ALLOWED_RESULT_STATUSES: Tuple[str, ...] = (
+    "answered",
+    "partially_answered",
+    "not_computable",
+    "not_operationalised",
+    "not_collected",
+    "review_required",
+)
+BASELINE_ACCOUNTABILITY_FIELDS = frozenset(
+    {
+        "question_id",
+        "result_status",
+        "view_kind",
+        "scientific_status",
+        "observational_unit",
+        "n",
+        "missing_n",
+        "denominator",
+        "method",
+        "evidence_references",
+        "validity_threats",
+        "permitted_interpretation",
+        "prohibited_interpretation",
+    }
+)
+ETQ_STATUS_BY_ID: Mapping[str, str] = {
+    "ETQ1": "not_operationalised",
+    "ETQ2": "not_operationalised",
+    "ETQ3": "not_operationalised",
+    "ETQ4": "not_operationalised",
+    "ETQ5": "not_operationalised",
+    "ETQ6": "not_operationalised",
+    "ETQ7": "not_collected",
+}
+SCIENTIFIC_STATUS_BY_RESULT: Mapping[str, str] = {
+    "answered": "answer_established",
+    "partially_answered": "answer_not_established",
+    "not_computable": "computation_blocked",
+    "not_operationalised": "operationalisation_required",
+    "not_collected": "collection_not_started",
+    "review_required": "review_required",
+}
+
+
+class ResearchQuestionRegistryError(ValueError):
+    """Raised when a registry or accountability ledger violates its contract."""
+
+
+@dataclass(frozen=True)
+class AxisIdentity:
+    """Canonical axis name/code pair."""
+
+    canonical_name: str
+    display_code: str
+    meaning: str
+
+
+@dataclass(frozen=True)
+class MethodSpecification:
+    """A declared analytical method and its readiness boundary."""
+
+    name: str
+    readiness: str
+    approval_status: str
+    prerequisite: str
+    implementation_reference: str = ""
+
+
+@dataclass(frozen=True)
+class ResearchQuestion:
+    """A typed operational research-question declaration."""
+
+    question_id: str
+    parent_id: str
+    text: str
+    status: str
+    axis_name: str
+    axis_code: str
+    construct: str
+    population_definition: str
+    target_view: str
+    view_kind: str
+    observational_unit: str
+    variables: Tuple[str, ...]
+    indicators: Tuple[str, ...]
+    measures: Tuple[str, ...]
+    denominator: str
+    missing_handling: str
+    excluded_handling: str
+    evidence_boundary: str
+    methods: Tuple[MethodSpecification, ...]
+    permitted_interpretation: str
+    prohibited_interpretation: str
+    materialization_status: str
+    materialization_readiness: str
+    artifact_path: str
+    repository_source_basis: Tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class ExtendedQuestion:
+    """A typed, explicitly non-operationalised or non-collected question."""
+
+    question_id: str
+    text: str
+    status: str
+    prerequisites: Tuple[str, ...]
+    permitted_interpretation: str
+    prohibited_interpretation: str
+    repository_source_basis: Tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class ProtocolReference:
+    """Versioned reference to authoritative protocol hypotheses."""
+
+    version: str
+    ordered_hypothesis_ids: Tuple[str, ...]
+    declared_outcomes: Mapping[str, Tuple[str, ...]]
+    fingerprint: str
+
+
+@dataclass(frozen=True)
+class ResearchQuestionRegistry:
+    """Validated research-question registry."""
+
+    version: str
+    status: str
+    fingerprint: str
+    axes: Tuple[AxisIdentity, ...]
+    questions: Tuple[ResearchQuestion, ...]
+    extended_questions: Tuple[ExtendedQuestion, ...]
+    protocol: ProtocolReference
+
+    @property
+    def all_question_ids(self) -> Tuple[str, ...]:
+        """Return the complete deterministic accountability order."""
+
+        return tuple(question.question_id for question in self.questions) + tuple(
+            question.question_id for question in self.extended_questions
+        )
+
+
+@dataclass(frozen=True)
+class AccountabilityEntry:
+    """Typed accountability row after schema and scientific validation."""
+
+    question_id: str
+    item_type: str
+    result_status: str
+    view_kind: str
+    scientific_status: str
+    observational_unit: str
+    population_definition: str
+    n: int | None
+    missing_n: int | None
+    excluded_n: int | None
+    denominator: str
+    method: str
+    method_readiness: str
+    evidence_references: Tuple[str, ...]
+    validity_threats: Tuple[str, ...]
+    permitted_interpretation: str
+    prohibited_interpretation: str
+    registry_version: str
+    registry_fingerprint: str
+    protocol_version: str
+    protocol_fingerprint: str
+    identity_schema_version: str
+    classifier_version: str
+    analysis_timestamp: str
+    warnings: Tuple[str, ...]
+    hypothesis_results: Tuple["HypothesisAccountability", ...]
+
+
+@dataclass(frozen=True)
+class HypothesisAccountability:
+    """One protocol-declared hypothesis outcome retained under RQ8."""
+
+    hypothesis_id: str
+    outcome: str
+    validated_supply_status: str
+    evidence_references: Tuple[str, ...]
+    warnings: Tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class AccountabilityLedger:
+    """Complete, validated accountability ledger."""
+
+    version: str
+    entries: Tuple[AccountabilityEntry, ...]
+
+
+def _load_yaml_mapping(path: Path, label: str) -> dict[str, Any]:
+    if not path.is_file():
+        raise ResearchQuestionRegistryError(f"{label} does not exist: {path}")
+    try:
+        payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        raise ResearchQuestionRegistryError(f"{label} is not valid YAML: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise ResearchQuestionRegistryError(f"{label} must contain a top-level object")
+    return cast(dict[str, Any], payload)
+
+
+def _load_schema(path: Path) -> dict[str, Any]:
+    if not path.is_file():
+        raise ResearchQuestionRegistryError(f"schema does not exist: {path}")
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ResearchQuestionRegistryError(f"schema is not valid JSON: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise ResearchQuestionRegistryError("schema must contain a top-level object")
+    Draft202012Validator.check_schema(payload)
+    return cast(dict[str, Any], payload)
+
+
+def _json_fingerprint(payload: Mapping[str, Any]) -> str:
+    canonical = json.dumps(
+        payload,
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _schema_issues(
+    payload: Mapping[str, Any],
+    schema_path: Path,
+) -> list[str]:
+    validator = Draft202012Validator(
+        _load_schema(schema_path),
+        format_checker=FormatChecker(),
+    )
+    issues: list[str] = []
+    for error in sorted(validator.iter_errors(payload), key=lambda item: list(item.path)):
+        location = ".".join(str(part) for part in error.path) or "<root>"
+        issues.append(f"{location}: {error.message}")
+    return issues
+
+
+def _protocol_reference(protocol_path: Path) -> ProtocolReference:
+    payload = _load_yaml_mapping(protocol_path, "authoritative protocol")
+    hypotheses = payload.get("hypotheses")
+    if not isinstance(hypotheses, dict) or not hypotheses:
+        raise ResearchQuestionRegistryError(
+            "authoritative protocol must declare a non-empty hypotheses object"
+        )
+    version = payload.get("protocol_version")
+    if not isinstance(version, str) or not version.strip():
+        raise ResearchQuestionRegistryError(
+            "authoritative protocol must declare protocol_version"
+        )
+    declared_outcomes: dict[str, Tuple[str, ...]] = {}
+    for hypothesis_id, declaration in hypotheses.items():
+        if not isinstance(declaration, dict):
+            raise ResearchQuestionRegistryError(
+                f"authoritative protocol hypothesis {hypothesis_id} must be an object"
+            )
+        outcomes = declaration.get("declared_outcomes")
+        if not isinstance(outcomes, list) or not outcomes:
+            raise ResearchQuestionRegistryError(
+                f"authoritative protocol hypothesis {hypothesis_id} must declare outcomes"
+            )
+        declared_outcomes[str(hypothesis_id)] = tuple(str(item) for item in outcomes)
+    return ProtocolReference(
+        version=version.strip(),
+        ordered_hypothesis_ids=tuple(str(key) for key in hypotheses),
+        declared_outcomes=declared_outcomes,
+        fingerprint=hashlib.sha256(protocol_path.read_bytes()).hexdigest(),
+    )
+
+
+def _resolve_repository_path(repo_root: Path, value: str) -> Path | None:
+    candidate = Path(value)
+    if candidate.is_absolute():
+        return None
+    resolved_root = repo_root.resolve()
+    resolved = (resolved_root / candidate).resolve()
+    try:
+        resolved.relative_to(resolved_root)
+    except ValueError:
+        return None
+    return resolved
+
+
+def _semantic_registry_issues(
+    payload: Mapping[str, Any],
+    protocol: ProtocolReference,
+    repo_root: Path,
+) -> list[str]:
+    issues: list[str] = []
+    axes = cast(Sequence[Mapping[str, Any]], payload.get("canonical_axes", []))
+    axis_pairs = tuple(
+        (str(axis.get("canonical_name", "")), str(axis.get("display_code", "")))
+        for axis in axes
+    )
+    if axis_pairs != CANONICAL_AXES:
+        issues.append(
+            "canonical_axes must preserve ordered pairs "
+            "MARINE/M, MARITIME/T, OCEANIC/O, HYDRONIZATION/H"
+        )
+
+    questions = cast(Sequence[Mapping[str, Any]], payload.get("questions", []))
+    extended = cast(
+        Sequence[Mapping[str, Any]], payload.get("extended_questions", [])
+    )
+    question_ids = tuple(str(item.get("id", "")) for item in questions)
+    extended_ids = tuple(str(item.get("id", "")) for item in extended)
+    all_ids = question_ids + extended_ids
+    if len(all_ids) != len(set(all_ids)):
+        issues.append("question IDs must be unique across questions and extended_questions")
+    if question_ids != REQUIRED_QUESTION_IDS:
+        issues.append(
+            "questions must preserve the approved order: "
+            + ", ".join(REQUIRED_QUESTION_IDS)
+        )
+    if extended_ids != REQUIRED_EXTENDED_QUESTION_IDS:
+        issues.append(
+            "extended_questions must preserve the approved order: "
+            + ", ".join(REQUIRED_EXTENDED_QUESTION_IDS)
+        )
+
+    question_id_set = set(question_ids)
+    for question in questions:
+        question_id = str(question.get("id", ""))
+        parent_id = str(question.get("parent_id", ""))
+        if parent_id and (parent_id == question_id or parent_id not in question_id_set):
+            issues.append(f"{question_id}: parent_id must reference another RQ")
+        if "." in question_id and not parent_id:
+            issues.append(f"{question_id}: child question requires parent_id")
+        expected_axis = RQ4_AXIS_CONTRACT.get(question_id)
+        if expected_axis is not None:
+            actual_axis = (
+                str(question.get("axis_name", "")),
+                str(question.get("axis_code", "")),
+            )
+            if parent_id != "RQ4":
+                issues.append(f"{question_id}: parent_id must be RQ4")
+            if actual_axis != expected_axis:
+                issues.append(
+                    f"{question_id}: expected canonical axis "
+                    f"{expected_axis[0]}/{expected_axis[1]}"
+                )
+        elif "axis_name" in question or "axis_code" in question:
+            name = str(question.get("axis_name", ""))
+            code = str(question.get("axis_code", ""))
+            if (name, code) not in CANONICAL_AXES:
+                issues.append(f"{question_id}: noncanonical axis pair {name}/{code}")
+
+        method_names: set[str] = set()
+        methods = cast(Sequence[Mapping[str, Any]], question.get("methods", []))
+        for method in methods:
+            name = str(method.get("name", ""))
+            if name in method_names:
+                issues.append(f"{question_id}: duplicate method {name}")
+            method_names.add(name)
+            if str(method.get("readiness", "")) == "implemented":
+                if str(method.get("approval_status", "")) != "repository_approved":
+                    issues.append(
+                        f"{question_id}.{name}: implemented method requires "
+                        "repository_approved"
+                    )
+                reference = str(method.get("implementation_reference", ""))
+                resolved_reference = _resolve_repository_path(repo_root, reference)
+                if not reference or resolved_reference is None or not resolved_reference.is_file():
+                    issues.append(
+                        f"{question_id}.{name}: implemented method requires an "
+                        "existing repository implementation_reference"
+                    )
+
+        materialization = cast(
+            Mapping[str, Any], question.get("materialization", {})
+        )
+        if str(materialization.get("status", "")) == "materialized":
+            artifact_path = str(materialization.get("artifact_path", ""))
+            resolved_artifact = _resolve_repository_path(repo_root, artifact_path)
+            if (
+                not artifact_path
+                or resolved_artifact is None
+                or not resolved_artifact.exists()
+            ):
+                issues.append(
+                    f"{question_id}: materialized target requires an existing "
+                    "repository artifact_path"
+                )
+
+        for source in cast(
+            Sequence[str], question.get("repository_source_basis", [])
+        ):
+            resolved_source = _resolve_repository_path(repo_root, str(source))
+            if resolved_source is None or not resolved_source.is_file():
+                issues.append(
+                    f"{question_id}: repository_source_basis does not resolve: {source}"
+                )
+
+    for question in extended:
+        question_id = str(question.get("id", ""))
+        expected_status = ETQ_STATUS_BY_ID.get(question_id)
+        if expected_status and question.get("status") != expected_status:
+            issues.append(
+                f"{question_id}: expected status {expected_status}, "
+                f"got {question.get('status')}"
+            )
+        for source in cast(
+            Sequence[str], question.get("repository_source_basis", [])
+        ):
+            resolved_source = _resolve_repository_path(repo_root, str(source))
+            if resolved_source is None or not resolved_source.is_file():
+                issues.append(
+                    f"{question_id}: repository_source_basis does not resolve: {source}"
+                )
+
+    hypothesis_reference = cast(
+        Mapping[str, Any], payload.get("hypothesis_reference", {})
+    )
+    registry_hypothesis_ids = tuple(
+        str(item) for item in hypothesis_reference.get("ordered_ids", [])
+    )
+    if registry_hypothesis_ids != protocol.ordered_hypothesis_ids:
+        issues.append(
+            "hypothesis_reference.ordered_ids must exactly match the authoritative "
+            "protocol order"
+        )
+    h2_rule = cast(
+        Mapping[str, Any], hypothesis_reference.get("h2_supply_rule", {})
+    )
+    if (
+        h2_rule.get("minimum_eqf_levels") != [6, 7]
+        or h2_rule.get("required_supply_status") != "independently_validated"
+        or h2_rule.get("generated_designs_are_supply") is not False
+        or h2_rule.get("default_without_supply") != "not_computable"
+    ):
+        issues.append(
+            "H2 must remain not_computable without independently validated "
+            "EQF 6-7 supply, and generated designs cannot count as supply"
+        )
+
+    allowed_statuses = tuple(
+        str(item) for item in payload.get("allowed_result_statuses", [])
+    )
+    if allowed_statuses != ALLOWED_RESULT_STATUSES:
+        issues.append("allowed_result_statuses must preserve the approved contract")
+    required_fields = {
+        str(item) for item in payload.get("required_accountability_fields", [])
+    }
+    missing_baseline = BASELINE_ACCOUNTABILITY_FIELDS - required_fields
+    if missing_baseline:
+        issues.append(
+            "required_accountability_fields is missing: "
+            + ", ".join(sorted(missing_baseline))
+        )
+    return issues
+
+
+def _parse_method(payload: Mapping[str, Any]) -> MethodSpecification:
+    return MethodSpecification(
+        name=str(payload["name"]),
+        readiness=str(payload["readiness"]),
+        approval_status=str(payload["approval_status"]),
+        prerequisite=str(payload["prerequisite"]),
+        implementation_reference=str(payload.get("implementation_reference", "")),
+    )
+
+
+def _parse_research_question(payload: Mapping[str, Any]) -> ResearchQuestion:
+    materialization = cast(Mapping[str, Any], payload["materialization"])
+    return ResearchQuestion(
+        question_id=str(payload["id"]),
+        parent_id=str(payload.get("parent_id", "")),
+        text=str(payload["text"]),
+        status=str(payload["status"]),
+        axis_name=str(payload.get("axis_name", "")),
+        axis_code=str(payload.get("axis_code", "")),
+        construct=str(payload["construct"]),
+        population_definition=str(payload["population_definition"]),
+        target_view=str(payload["target_view"]),
+        view_kind=str(payload["view_kind"]),
+        observational_unit=str(payload["observational_unit"]),
+        variables=tuple(str(item) for item in payload["variables"]),
+        indicators=tuple(str(item) for item in payload["indicators"]),
+        measures=tuple(str(item) for item in payload["measures"]),
+        denominator=str(payload["denominator"]),
+        missing_handling=str(payload["missing_handling"]),
+        excluded_handling=str(payload["excluded_handling"]),
+        evidence_boundary=str(payload["evidence_boundary"]),
+        methods=tuple(
+            _parse_method(cast(Mapping[str, Any], item))
+            for item in payload["methods"]
+        ),
+        permitted_interpretation=str(payload["permitted_interpretation"]),
+        prohibited_interpretation=str(payload["prohibited_interpretation"]),
+        materialization_status=str(materialization["status"]),
+        materialization_readiness=str(materialization["readiness"]),
+        artifact_path=str(materialization["artifact_path"]),
+        repository_source_basis=tuple(
+            str(item) for item in payload["repository_source_basis"]
+        ),
+    )
+
+
+def _parse_extended_question(payload: Mapping[str, Any]) -> ExtendedQuestion:
+    return ExtendedQuestion(
+        question_id=str(payload["id"]),
+        text=str(payload["text"]),
+        status=str(payload["status"]),
+        prerequisites=tuple(str(item) for item in payload["prerequisites"]),
+        permitted_interpretation=str(payload["permitted_interpretation"]),
+        prohibited_interpretation=str(payload["prohibited_interpretation"]),
+        repository_source_basis=tuple(
+            str(item) for item in payload["repository_source_basis"]
+        ),
+    )
+
+
+def load_research_question_registry(
+    path: Path = DEFAULT_REGISTRY_PATH,
+    *,
+    protocol_path: Path = DEFAULT_PROTOCOL_PATH,
+    schema_path: Path = DEFAULT_REGISTRY_SCHEMA_PATH,
+    repo_root: Path = REPO_ROOT,
+) -> ResearchQuestionRegistry:
+    """Load and validate the proposed registry against schema and protocol."""
+
+    payload = _load_yaml_mapping(path, "research-question registry")
+    issues = _schema_issues(payload, schema_path)
+    protocol = _protocol_reference(protocol_path)
+    if not issues:
+        issues.extend(_semantic_registry_issues(payload, protocol, repo_root))
+    if issues:
+        raise ResearchQuestionRegistryError(
+            "research-question registry validation failed:\n- "
+            + "\n- ".join(issues)
+        )
+
+    axes = tuple(
+        AxisIdentity(
+            canonical_name=str(axis["canonical_name"]),
+            display_code=str(axis["display_code"]),
+            meaning=str(axis["meaning"]),
+        )
+        for axis in cast(Sequence[Mapping[str, Any]], payload["canonical_axes"])
+    )
+    questions = tuple(
+        _parse_research_question(question)
+        for question in cast(Sequence[Mapping[str, Any]], payload["questions"])
+    )
+    extended_questions = tuple(
+        _parse_extended_question(question)
+        for question in cast(
+            Sequence[Mapping[str, Any]], payload["extended_questions"]
+        )
+    )
+    return ResearchQuestionRegistry(
+        version=str(payload["registry_version"]),
+        status=str(payload["status"]),
+        fingerprint=_json_fingerprint(payload),
+        axes=axes,
+        questions=questions,
+        extended_questions=extended_questions,
+        protocol=protocol,
+    )
+
+
+def _accountability_semantic_issues(
+    payload: Mapping[str, Any],
+    registry: ResearchQuestionRegistry,
+) -> list[str]:
+    issues: list[str] = []
+    entries = cast(Sequence[Mapping[str, Any]], payload.get("entries", []))
+    entry_ids = tuple(str(entry.get("question_id", "")) for entry in entries)
+    if len(entry_ids) != len(set(entry_ids)):
+        issues.append("accountability ledger contains duplicate question_id values")
+    expected_ids = registry.all_question_ids
+    if set(entry_ids) != set(expected_ids):
+        missing = sorted(set(expected_ids) - set(entry_ids))
+        unexpected = sorted(set(entry_ids) - set(expected_ids))
+        if missing:
+            issues.append("accountability ledger omits: " + ", ".join(missing))
+        if unexpected:
+            issues.append(
+                "accountability ledger contains unregistered IDs: "
+                + ", ".join(unexpected)
+            )
+    if entry_ids != expected_ids:
+        issues.append("accountability ledger entries must preserve registry order")
+
+    research_questions = {
+        question.question_id: question for question in registry.questions
+    }
+    extended_questions = {
+        question.question_id: question for question in registry.extended_questions
+    }
+    metadata_tuples: set[tuple[str, ...]] = set()
+    for entry in entries:
+        question_id = str(entry.get("question_id", ""))
+        result_status = str(entry.get("result_status", ""))
+        expected_scientific_status = SCIENTIFIC_STATUS_BY_RESULT.get(result_status)
+        if entry.get("scientific_status") != expected_scientific_status:
+            issues.append(
+                f"{question_id}: scientific_status must be "
+                f"{expected_scientific_status} for {result_status}"
+            )
+
+        metadata = (
+            str(entry.get("registry_version", "")),
+            str(entry.get("registry_fingerprint", "")),
+            str(entry.get("protocol_version", "")),
+            str(entry.get("protocol_fingerprint", "")),
+            str(entry.get("identity_schema_version", "")),
+            str(entry.get("classifier_version", "")),
+            str(entry.get("analysis_timestamp", "")),
+        )
+        metadata_tuples.add(metadata)
+        if entry.get("registry_version") != registry.version:
+            issues.append(f"{question_id}: registry_version mismatch")
+        if entry.get("registry_fingerprint") != registry.fingerprint:
+            issues.append(f"{question_id}: registry_fingerprint mismatch")
+        if entry.get("protocol_version") != registry.protocol.version:
+            issues.append(f"{question_id}: protocol_version mismatch")
+        if entry.get("protocol_fingerprint") != registry.protocol.fingerprint:
+            issues.append(f"{question_id}: protocol_fingerprint mismatch")
+
+        if question_id in extended_questions:
+            extended_question = extended_questions[question_id]
+            expected_result = extended_question.status
+            if result_status != expected_result:
+                issues.append(
+                    f"{question_id}: extended question result_status must remain "
+                    f"{expected_result}"
+                )
+            if entry.get("item_type") != "extended_question":
+                issues.append(f"{question_id}: item_type must be extended_question")
+            if entry.get("view_kind") != "not_defined":
+                issues.append(f"{question_id}: view_kind must be not_defined")
+            if entry.get("observational_unit") != "not_defined_pending_operationalisation":
+                issues.append(
+                    f"{question_id}: observational_unit must remain undefined"
+                )
+            if entry.get("population_definition") != "not_defined_pending_operationalisation":
+                issues.append(
+                    f"{question_id}: population_definition must remain undefined"
+                )
+            if entry.get("denominator") != "not_defined_pending_operationalisation":
+                issues.append(f"{question_id}: denominator must remain undefined")
+            if entry.get("method") != "not_applicable":
+                issues.append(f"{question_id}: method must be not_applicable")
+            if entry.get("method_readiness") != "not_applicable":
+                issues.append(
+                    f"{question_id}: method_readiness must be not_applicable"
+                )
+            if any(entry.get(field) is not None for field in ("n", "missing_n", "excluded_n")):
+                issues.append(
+                    f"{question_id}: counts must be null while not operationalised "
+                    "or not collected"
+                )
+            if entry.get("evidence_references"):
+                issues.append(
+                    f"{question_id}: non-operationalised/non-collected entry "
+                    "cannot contain evidence_references"
+                )
+            if (
+                entry.get("permitted_interpretation")
+                != extended_question.permitted_interpretation
+            ):
+                issues.append(f"{question_id}: permitted_interpretation drift")
+            if (
+                entry.get("prohibited_interpretation")
+                != extended_question.prohibited_interpretation
+            ):
+                issues.append(f"{question_id}: prohibited_interpretation drift")
+        elif question_id in research_questions:
+            research_question = research_questions[question_id]
+            if entry.get("item_type") != "research_question":
+                issues.append(f"{question_id}: item_type must be research_question")
+            if entry.get("view_kind") != research_question.view_kind:
+                issues.append(f"{question_id}: view_kind must match the registry")
+            if (
+                entry.get("observational_unit")
+                != research_question.observational_unit
+            ):
+                issues.append(
+                    f"{question_id}: observational_unit must match the registry"
+                )
+            if (
+                entry.get("population_definition")
+                != research_question.population_definition
+            ):
+                issues.append(
+                    f"{question_id}: population_definition must match the registry"
+                )
+            if entry.get("denominator") != research_question.denominator:
+                issues.append(f"{question_id}: denominator must match the registry")
+            if (
+                entry.get("permitted_interpretation")
+                != research_question.permitted_interpretation
+            ):
+                issues.append(f"{question_id}: permitted_interpretation drift")
+            if (
+                entry.get("prohibited_interpretation")
+                != research_question.prohibited_interpretation
+            ):
+                issues.append(f"{question_id}: prohibited_interpretation drift")
+
+            selected_method = next(
+                (
+                    method
+                    for method in research_question.methods
+                    if method.name == entry.get("method")
+                ),
+                None,
+            )
+            if selected_method is None:
+                issues.append(f"{question_id}: method is not declared by the registry")
+            elif entry.get("method_readiness") != selected_method.readiness:
+                issues.append(
+                    f"{question_id}: method_readiness must match the registry method"
+                )
+
+            if result_status in {"answered", "partially_answered"}:
+                if research_question.materialization_status != "materialized":
+                    issues.append(
+                        f"{question_id}: answered state requires a materialized target"
+                    )
+                if selected_method is None or selected_method.readiness != "implemented":
+                    issues.append(
+                        f"{question_id}: answered state requires an implemented method"
+                    )
+                if entry.get("n") is None:
+                    issues.append(f"{question_id}: answered state requires n")
+                if not entry.get("evidence_references"):
+                    issues.append(
+                        f"{question_id}: answered state requires evidence_references"
+                    )
+            if result_status in {
+                "not_computable",
+                "not_operationalised",
+                "not_collected",
+                "review_required",
+            } and not entry.get("warnings"):
+                issues.append(f"{question_id}: unresolved state requires warnings")
+
+            hypothesis_results = cast(
+                Sequence[Mapping[str, Any]], entry.get("hypothesis_results", [])
+            )
+            if question_id == "RQ8":
+                hypothesis_ids = tuple(
+                    str(result.get("hypothesis_id", ""))
+                    for result in hypothesis_results
+                )
+                if hypothesis_ids != registry.protocol.ordered_hypothesis_ids:
+                    issues.append(
+                        "RQ8: hypothesis_results must preserve every authoritative "
+                        "protocol hypothesis in order"
+                    )
+                for result in hypothesis_results:
+                    hypothesis_id = str(result.get("hypothesis_id", ""))
+                    outcome = str(result.get("outcome", ""))
+                    if outcome not in registry.protocol.declared_outcomes.get(
+                        hypothesis_id, ()
+                    ):
+                        issues.append(
+                            f"RQ8.{hypothesis_id}: outcome is not declared by the "
+                            "authoritative protocol"
+                        )
+                    supply_status = str(
+                        result.get("validated_supply_status", "")
+                    )
+                    if hypothesis_id == "H2":
+                        if (
+                            supply_status != "independently_validated"
+                            and outcome != "not_computable"
+                        ):
+                            issues.append(
+                                "RQ8.H2: outcome must remain not_computable without "
+                                "independently validated EQF 6-7 supply"
+                            )
+                    elif supply_status != "not_applicable":
+                        issues.append(
+                            f"RQ8.{hypothesis_id}: validated_supply_status must be "
+                            "not_applicable"
+                        )
+            elif hypothesis_results:
+                issues.append(
+                    f"{question_id}: hypothesis_results are only permitted for RQ8"
+                )
+
+    if len(metadata_tuples) > 1:
+        issues.append(
+            "all accountability entries must use one registry, protocol, identity, "
+            "classifier and analysis timestamp snapshot"
+        )
+    return issues
+
+
+def _parse_accountability_entry(payload: Mapping[str, Any]) -> AccountabilityEntry:
+    return AccountabilityEntry(
+        question_id=str(payload["question_id"]),
+        item_type=str(payload["item_type"]),
+        result_status=str(payload["result_status"]),
+        view_kind=str(payload["view_kind"]),
+        scientific_status=str(payload["scientific_status"]),
+        observational_unit=str(payload["observational_unit"]),
+        population_definition=str(payload["population_definition"]),
+        n=cast(int | None, payload["n"]),
+        missing_n=cast(int | None, payload["missing_n"]),
+        excluded_n=cast(int | None, payload["excluded_n"]),
+        denominator=str(payload["denominator"]),
+        method=str(payload["method"]),
+        method_readiness=str(payload["method_readiness"]),
+        evidence_references=tuple(
+            str(item) for item in payload["evidence_references"]
+        ),
+        validity_threats=tuple(str(item) for item in payload["validity_threats"]),
+        permitted_interpretation=str(payload["permitted_interpretation"]),
+        prohibited_interpretation=str(payload["prohibited_interpretation"]),
+        registry_version=str(payload["registry_version"]),
+        registry_fingerprint=str(payload["registry_fingerprint"]),
+        protocol_version=str(payload["protocol_version"]),
+        protocol_fingerprint=str(payload["protocol_fingerprint"]),
+        identity_schema_version=str(payload["identity_schema_version"]),
+        classifier_version=str(payload["classifier_version"]),
+        analysis_timestamp=str(payload["analysis_timestamp"]),
+        warnings=tuple(str(item) for item in payload["warnings"]),
+        hypothesis_results=tuple(
+            HypothesisAccountability(
+                hypothesis_id=str(item["hypothesis_id"]),
+                outcome=str(item["outcome"]),
+                validated_supply_status=str(item["validated_supply_status"]),
+                evidence_references=tuple(
+                    str(reference) for reference in item["evidence_references"]
+                ),
+                warnings=tuple(str(warning) for warning in item["warnings"]),
+            )
+            for item in cast(
+                Sequence[Mapping[str, Any]],
+                payload.get("hypothesis_results", []),
+            )
+        ),
+    )
+
+
+def validate_accountability_payload(
+    payload: Mapping[str, Any],
+    registry: ResearchQuestionRegistry,
+    *,
+    schema_path: Path = DEFAULT_ACCOUNTABILITY_SCHEMA_PATH,
+) -> AccountabilityLedger:
+    """Validate complete accountability coverage and reject manufactured answers."""
+
+    issues = _schema_issues(payload, schema_path)
+    if not issues:
+        issues.extend(_accountability_semantic_issues(payload, registry))
+    if issues:
+        raise ResearchQuestionRegistryError(
+            "research-question accountability validation failed:\n- "
+            + "\n- ".join(issues)
+        )
+    return AccountabilityLedger(
+        version=str(payload["ledger_version"]),
+        entries=tuple(
+            _parse_accountability_entry(entry)
+            for entry in cast(Sequence[Mapping[str, Any]], payload["entries"])
+        ),
+    )
+
+
+def load_accountability_ledger(
+    path: Path,
+    registry: ResearchQuestionRegistry,
+    *,
+    schema_path: Path = DEFAULT_ACCOUNTABILITY_SCHEMA_PATH,
+) -> AccountabilityLedger:
+    """Load a YAML or JSON accountability ledger and validate full coverage."""
+
+    payload = _load_yaml_mapping(path, "research-question accountability ledger")
+    return validate_accountability_payload(
+        payload,
+        registry,
+        schema_path=schema_path,
+    )

--- a/tests/test_research_question_registry.py
+++ b/tests/test_research_question_registry.py
@@ -1,0 +1,559 @@
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+from typing import Any, Callable, Mapping, Sequence, cast
+
+import pytest
+import yaml
+from jsonschema import Draft202012Validator
+
+from scripts.validate_research_question_registry import main as validator_main
+from src.scientific_sources.research_question_registry import (
+    ALLOWED_RESULT_STATUSES,
+    BASELINE_ACCOUNTABILITY_FIELDS,
+    CANONICAL_AXES,
+    DEFAULT_ACCOUNTABILITY_SCHEMA_PATH,
+    DEFAULT_PROTOCOL_PATH,
+    DEFAULT_REGISTRY_PATH,
+    DEFAULT_REGISTRY_SCHEMA_PATH,
+    REQUIRED_EXTENDED_QUESTION_IDS,
+    REQUIRED_QUESTION_IDS,
+    SCIENTIFIC_STATUS_BY_RESULT,
+    ResearchQuestionRegistry,
+    ResearchQuestionRegistryError,
+    load_research_question_registry,
+    validate_accountability_payload,
+)
+
+
+EXPECTED_RQ_TEXTS = (
+    "What detailed competences does the Blue Economy demand across the four "
+    "QMBD axes and 12 Blue Economy sectors?",
+    "What unique skills does the Blue Economy demand across the four QMBD axes "
+    "and 12 Blue Economy sectors?",
+    "What sector gaps are communicated across the four QMBD axes and 12 Blue "
+    "Economy sectors?",
+    "How are the 12 Blue Economy sectors distributed across cumulative "
+    "competences and QMBD axes?",
+    "What is the sector cross-table for the MARINE axis?",
+    "What is the sector cross-table for the MARITIME axis?",
+    "What is the sector cross-table for the OCEANIC axis?",
+    "What is the sector cross-table for the HYDRONIZATION axis?",
+    "What is the taxonomy of competences and skills needed to accelerate the "
+    "Blue Economy?",
+    "What is the taxonomy of structural competence and skill gaps constraining "
+    "Blue Economy demands?",
+    "What micro-credential pathways across the 12 sectors are proposed to "
+    "address identified competence gaps?",
+    "How do competence-demand and validated-credential distributions align "
+    "with or challenge H1, H2 and H3?",
+)
+EXPECTED_ETQ_TEXTS = (
+    "How do structural competence gaps across the 12 sectors reveal a systemic "
+    "deficit in sociological, ethical and governance skills?",
+    "What reviewed relations connect evidence authors, publishers and source "
+    "scope to baselines, validated credentials, EQF levels, target groups, "
+    "sectors, axes, dictionaries, competences and gaps?",
+    "How does QMBD translate Blue Economy and Blue Sustainability from "
+    "political ideology toward socio-technical reality?",
+    "What is the performativity of the World Ocean in competence demand, "
+    "educational deficits, courses, EQF mappings, credentials and dictionaries?",
+    "What is the performativity of the Blue Economy in competence demand, "
+    "educational deficits, courses, EQF mappings, credentials and dictionaries?",
+    "How are Blue Economy demands mediated across credentials, competences, "
+    "gaps, courses and EQF through marinization, maritimization, oceanization "
+    "and hydronization across sectors, domains and realms?",
+    "How do FAIR and CARE principles in maritime data governance protect local "
+    "and Indigenous knowledge during Marine Spatial Planning?",
+)
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert isinstance(payload, dict)
+    return cast(dict[str, Any], payload)
+
+
+def _write_mutated_registry(
+    tmp_path: Path,
+    mutate: Callable[[dict[str, Any]], None],
+) -> Path:
+    payload = copy.deepcopy(_load_yaml(DEFAULT_REGISTRY_PATH))
+    mutate(payload)
+    path = tmp_path / "research_question_registry.yml"
+    path.write_text(
+        yaml.safe_dump(payload, sort_keys=False, allow_unicode=False),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _expect_registry_failure(
+    tmp_path: Path,
+    mutate: Callable[[dict[str, Any]], None],
+    message: str,
+) -> None:
+    path = _write_mutated_registry(tmp_path, mutate)
+    with pytest.raises(ResearchQuestionRegistryError, match=message):
+        load_research_question_registry(path)
+
+
+def _future_accountability_payload(
+    registry: ResearchQuestionRegistry,
+) -> dict[str, Any]:
+    result_statuses = {
+        "RQ1": "review_required",
+        "RQ2": "not_operationalised",
+        "RQ3": "not_computable",
+        "RQ4": "review_required",
+        "RQ4.1": "review_required",
+        "RQ4.2": "review_required",
+        "RQ4.3": "review_required",
+        "RQ4.4": "review_required",
+        "RQ5": "not_operationalised",
+        "RQ6": "not_computable",
+        "RQ7": "review_required",
+        "RQ8": "not_computable",
+    }
+    common = {
+        "registry_version": registry.version,
+        "registry_fingerprint": registry.fingerprint,
+        "protocol_version": registry.protocol.version,
+        "protocol_fingerprint": registry.protocol.fingerprint,
+        "identity_schema_version": "2.0.0",
+        "classifier_version": "not_applied",
+        "analysis_timestamp": "2026-08-09T20:35:04Z",
+    }
+    entries: list[dict[str, Any]] = []
+    for question in registry.questions:
+        result_status = result_statuses[question.question_id]
+        method = question.methods[0]
+        entry = {
+            "question_id": question.question_id,
+            "item_type": "research_question",
+            "result_status": result_status,
+            "view_kind": question.view_kind,
+            "scientific_status": SCIENTIFIC_STATUS_BY_RESULT[result_status],
+            "observational_unit": question.observational_unit,
+            "population_definition": question.population_definition,
+            "n": None,
+            "missing_n": None,
+            "excluded_n": None,
+            "denominator": question.denominator,
+            "method": method.name,
+            "method_readiness": method.readiness,
+            "evidence_references": [],
+            "validity_threats": [
+                "The declared logical view is not materialized."
+            ],
+            "permitted_interpretation": question.permitted_interpretation,
+            "prohibited_interpretation": question.prohibited_interpretation,
+            "warnings": ["No empirical answer is established."],
+            **common,
+        }
+        if question.question_id == "RQ8":
+            entry["hypothesis_results"] = [
+                {
+                    "hypothesis_id": hypothesis_id,
+                    "outcome": "not_computable",
+                    "validated_supply_status": (
+                        "not_available"
+                        if hypothesis_id == "H2"
+                        else "not_applicable"
+                    ),
+                    "evidence_references": [],
+                    "warnings": ["Required inputs are not established."],
+                }
+                for hypothesis_id in registry.protocol.ordered_hypothesis_ids
+            ]
+        entries.append(entry)
+    for question in registry.extended_questions:
+        entries.append(
+            {
+                "question_id": question.question_id,
+                "item_type": "extended_question",
+                "result_status": question.status,
+                "view_kind": "not_defined",
+                "scientific_status": SCIENTIFIC_STATUS_BY_RESULT[question.status],
+                "observational_unit": "not_defined_pending_operationalisation",
+                "population_definition": "not_defined_pending_operationalisation",
+                "n": None,
+                "missing_n": None,
+                "excluded_n": None,
+                "denominator": "not_defined_pending_operationalisation",
+                "method": "not_applicable",
+                "method_readiness": "not_applicable",
+                "evidence_references": [],
+                "validity_threats": [
+                    "The question is not operationalised or not collected."
+                ],
+                "permitted_interpretation": question.permitted_interpretation,
+                "prohibited_interpretation": question.prohibited_interpretation,
+                "warnings": ["Prerequisites remain unresolved."],
+                **common,
+            }
+        )
+    return {"ledger_version": "1.0.0", "entries": entries}
+
+
+def _entry(payload: Mapping[str, Any], question_id: str) -> dict[str, Any]:
+    entries = cast(Sequence[dict[str, Any]], payload["entries"])
+    return next(item for item in entries if item["question_id"] == question_id)
+
+
+def test_registry_schemas_are_valid_draft_2020_12() -> None:
+    for path in (
+        DEFAULT_REGISTRY_SCHEMA_PATH,
+        DEFAULT_ACCOUNTABILITY_SCHEMA_PATH,
+    ):
+        schema = json.loads(path.read_text(encoding="utf-8"))
+        Draft202012Validator.check_schema(schema)
+
+
+def test_registry_preserves_exact_approved_agenda_order_and_wording() -> None:
+    registry = load_research_question_registry()
+
+    assert registry.status == "proposed_for_review"
+    assert tuple(item.question_id for item in registry.questions) == (
+        REQUIRED_QUESTION_IDS
+    )
+    assert tuple(item.text for item in registry.questions) == EXPECTED_RQ_TEXTS
+    assert tuple(item.question_id for item in registry.extended_questions) == (
+        REQUIRED_EXTENDED_QUESTION_IDS
+    )
+    assert tuple(item.text for item in registry.extended_questions) == (
+        EXPECTED_ETQ_TEXTS
+    )
+
+
+def test_registry_preserves_four_axis_name_code_pairs_and_rq4_children() -> None:
+    registry = load_research_question_registry()
+    axis_pairs = tuple(
+        (axis.canonical_name, axis.display_code) for axis in registry.axes
+    )
+    child_pairs = tuple(
+        (question.axis_name, question.axis_code)
+        for question in registry.questions
+        if question.parent_id == "RQ4"
+    )
+
+    assert axis_pairs == CANONICAL_AXES
+    assert child_pairs == CANONICAL_AXES
+
+
+def test_registry_ids_are_unique_and_parent_links_are_valid() -> None:
+    registry = load_research_question_registry()
+    all_ids = registry.all_question_ids
+    rq_ids = {question.question_id for question in registry.questions}
+
+    assert len(all_ids) == len(set(all_ids))
+    assert all(
+        not question.parent_id or question.parent_id in rq_ids
+        for question in registry.questions
+    )
+
+
+def test_extended_questions_keep_prerequisite_only_nonresult_status() -> None:
+    raw = _load_yaml(DEFAULT_REGISTRY_PATH)
+    extended = cast(Sequence[Mapping[str, Any]], raw["extended_questions"])
+
+    assert len(extended) == 7
+    assert [item["status"] for item in extended] == [
+        "not_operationalised",
+        "not_operationalised",
+        "not_operationalised",
+        "not_operationalised",
+        "not_operationalised",
+        "not_operationalised",
+        "not_collected",
+    ]
+    assert all(item["prerequisites"] for item in extended)
+    assert all("variables" not in item and "results" not in item for item in extended)
+
+
+def test_operational_questions_have_full_operationalisation_fields() -> None:
+    registry = load_research_question_registry()
+
+    for question in registry.questions:
+        assert question.construct
+        assert question.population_definition
+        assert question.view_kind
+        assert question.observational_unit
+        assert question.variables
+        assert question.indicators
+        assert question.measures
+        assert question.denominator
+        assert question.missing_handling
+        assert question.excluded_handling
+        assert question.evidence_boundary
+        assert question.methods
+        assert question.permitted_interpretation
+        assert question.prohibited_interpretation
+        assert question.repository_source_basis
+
+
+def test_registry_separates_planned_methods_from_materialized_implementation() -> None:
+    registry = load_research_question_registry()
+
+    assert all(
+        method.readiness in {"planned", "conditional"}
+        for question in registry.questions
+        for method in question.methods
+    )
+    assert all(
+        question.materialization_status == "logical_unmaterialized"
+        and question.materialization_readiness == "review_required"
+        and not question.artifact_path
+        for question in registry.questions
+    )
+
+
+def test_protocol_hypothesis_ids_match_exactly_without_definition_duplication() -> None:
+    registry = load_research_question_registry()
+    protocol = _load_yaml(DEFAULT_PROTOCOL_PATH)
+    raw_registry = _load_yaml(DEFAULT_REGISTRY_PATH)
+    reference = cast(Mapping[str, Any], raw_registry["hypothesis_reference"])
+
+    assert registry.protocol.ordered_hypothesis_ids == tuple(protocol["hypotheses"])
+    assert reference["ordered_ids"] == list(protocol["hypotheses"])
+    assert "definitions" not in reference
+    assert "definition" not in reference
+
+
+def test_h2_requires_independent_eqf_6_7_supply_and_excludes_designs() -> None:
+    raw = _load_yaml(DEFAULT_REGISTRY_PATH)
+    reference = cast(Mapping[str, Any], raw["hypothesis_reference"])
+    h2_rule = cast(Mapping[str, Any], reference["h2_supply_rule"])
+
+    assert h2_rule == {
+        "minimum_eqf_levels": [6, 7],
+        "required_supply_status": "independently_validated",
+        "generated_designs_are_supply": False,
+        "default_without_supply": "not_computable",
+    }
+
+
+def test_query_provenance_and_candidate_design_boundaries_are_explicit() -> None:
+    registry = load_research_question_registry()
+    all_boundaries = " ".join(
+        question.evidence_boundary.lower() for question in registry.questions
+    )
+    rq7 = next(item for item in registry.questions if item.question_id == "RQ7")
+
+    assert "source_query" in all_boundaries
+    assert "provenance only" in all_boundaries
+    assert "validated supply" in rq7.prohibited_interpretation
+
+
+def test_accountability_schema_retains_baseline_and_stronger_provenance() -> None:
+    schema = json.loads(
+        DEFAULT_ACCOUNTABILITY_SCHEMA_PATH.read_text(encoding="utf-8")
+    )
+    required = set(schema["$defs"]["accountabilityEntry"]["required"])
+
+    assert BASELINE_ACCOUNTABILITY_FIELDS <= required
+    assert {
+        "item_type",
+        "population_definition",
+        "excluded_n",
+        "method_readiness",
+        "registry_version",
+        "registry_fingerprint",
+        "protocol_version",
+        "protocol_fingerprint",
+        "identity_schema_version",
+        "classifier_version",
+        "analysis_timestamp",
+        "warnings",
+    } <= required
+
+
+def test_future_accountability_covers_every_question_and_unresolved_status() -> None:
+    registry = load_research_question_registry()
+    payload = _future_accountability_payload(registry)
+    ledger = validate_accountability_payload(payload, registry)
+
+    assert tuple(item.question_id for item in ledger.entries) == (
+        registry.all_question_ids
+    )
+    statuses = {item.result_status for item in ledger.entries}
+    assert {
+        "not_computable",
+        "not_operationalised",
+        "not_collected",
+        "review_required",
+    } <= statuses
+    assert set(ALLOWED_RESULT_STATUSES) > statuses
+    rq8 = next(item for item in ledger.entries if item.question_id == "RQ8")
+    assert tuple(
+        item.hypothesis_id for item in rq8.hypothesis_results
+    ) == registry.protocol.ordered_hypothesis_ids
+    assert all(item.outcome == "not_computable" for item in rq8.hypothesis_results)
+
+
+def test_duplicate_question_ids_are_rejected(tmp_path: Path) -> None:
+    def mutate(payload: dict[str, Any]) -> None:
+        payload["questions"][1]["id"] = "RQ1"
+
+    _expect_registry_failure(tmp_path, mutate, "unique")
+
+
+def test_invalid_parent_link_is_rejected(tmp_path: Path) -> None:
+    def mutate(payload: dict[str, Any]) -> None:
+        payload["questions"][4]["parent_id"] = "RQ99"
+
+    _expect_registry_failure(tmp_path, mutate, "parent_id")
+
+
+def test_noncanonical_rq4_axis_pair_is_rejected(tmp_path: Path) -> None:
+    def mutate(payload: dict[str, Any]) -> None:
+        payload["questions"][4]["axis_name"] = "OCEANIC"
+        payload["questions"][4]["axis_code"] = "O"
+
+    _expect_registry_failure(tmp_path, mutate, "expected canonical axis")
+
+
+def test_unknown_question_status_is_rejected(tmp_path: Path) -> None:
+    def mutate(payload: dict[str, Any]) -> None:
+        payload["questions"][0]["status"] = "answered"
+
+    _expect_registry_failure(tmp_path, mutate, "is not one of")
+
+
+def test_missing_operational_field_is_rejected(tmp_path: Path) -> None:
+    def mutate(payload: dict[str, Any]) -> None:
+        del payload["questions"][0]["denominator"]
+
+    _expect_registry_failure(tmp_path, mutate, "denominator.*required")
+
+
+def test_unapproved_method_cannot_be_represented_as_implemented(
+    tmp_path: Path,
+) -> None:
+    def mutate(payload: dict[str, Any]) -> None:
+        payload["questions"][0]["methods"][0]["readiness"] = "implemented"
+
+    _expect_registry_failure(tmp_path, mutate, "repository_approved")
+
+
+def test_unresolved_artifact_cannot_be_represented_as_materialized(
+    tmp_path: Path,
+) -> None:
+    def mutate(payload: dict[str, Any]) -> None:
+        materialization = payload["questions"][0]["materialization"]
+        materialization["status"] = "materialized"
+        materialization["readiness"] = "ready"
+        materialization["artifact_path"] = "outputs/not-a-real-rq-view.json"
+
+    _expect_registry_failure(tmp_path, mutate, "existing repository artifact_path")
+
+
+def test_protocol_hypothesis_id_mismatch_is_rejected(tmp_path: Path) -> None:
+    def mutate(payload: dict[str, Any]) -> None:
+        payload["hypothesis_reference"]["ordered_ids"] = ["H1", "H3", "H2"]
+
+    _expect_registry_failure(tmp_path, mutate, "authoritative protocol order")
+
+
+def test_h2_generated_supply_or_answer_default_is_rejected(tmp_path: Path) -> None:
+    def mutate(payload: dict[str, Any]) -> None:
+        h2_rule = payload["hypothesis_reference"]["h2_supply_rule"]
+        h2_rule["generated_designs_are_supply"] = True
+        h2_rule["default_without_supply"] = "answered"
+
+    _expect_registry_failure(tmp_path, mutate, "False was expected")
+
+
+def test_incomplete_accountability_ledger_is_rejected() -> None:
+    registry = load_research_question_registry()
+    payload = _future_accountability_payload(registry)
+    cast(list[dict[str, Any]], payload["entries"]).pop()
+
+    with pytest.raises(ResearchQuestionRegistryError, match="omits: ETQ7"):
+        validate_accountability_payload(payload, registry)
+
+
+def test_accountability_entry_missing_baseline_field_is_rejected() -> None:
+    registry = load_research_question_registry()
+    payload = _future_accountability_payload(registry)
+    del _entry(payload, "RQ1")["evidence_references"]
+
+    with pytest.raises(
+        ResearchQuestionRegistryError,
+        match="evidence_references.*required",
+    ):
+        validate_accountability_payload(payload, registry)
+
+
+def test_manufactured_answered_state_is_rejected() -> None:
+    registry = load_research_question_registry()
+    payload = _future_accountability_payload(registry)
+    rq1 = _entry(payload, "RQ1")
+    rq1.update(
+        {
+            "result_status": "answered",
+            "scientific_status": "answer_established",
+            "n": 1,
+            "missing_n": 0,
+            "excluded_n": 0,
+            "evidence_references": ["fragment:fixture-not-empirical"],
+            "warnings": [],
+        }
+    )
+
+    with pytest.raises(
+        ResearchQuestionRegistryError,
+        match="answered state requires a materialized target",
+    ):
+        validate_accountability_payload(payload, registry)
+
+
+def test_h2_cannot_claim_support_without_independent_validated_supply() -> None:
+    registry = load_research_question_registry()
+    payload = _future_accountability_payload(registry)
+    rq8 = _entry(payload, "RQ8")
+    hypothesis_results = cast(
+        list[dict[str, Any]], rq8["hypothesis_results"]
+    )
+    h2 = next(
+        item for item in hypothesis_results if item["hypothesis_id"] == "H2"
+    )
+    h2["outcome"] = "supported"
+    h2["validated_supply_status"] = "not_available"
+
+    with pytest.raises(
+        ResearchQuestionRegistryError,
+        match="must remain not_computable",
+    ):
+        validate_accountability_payload(payload, registry)
+
+
+def test_extended_question_cannot_be_manufactured_as_answered() -> None:
+    registry = load_research_question_registry()
+    payload = _future_accountability_payload(registry)
+    etq1 = _entry(payload, "ETQ1")
+    etq1["result_status"] = "answered"
+    etq1["scientific_status"] = "answer_established"
+
+    with pytest.raises(
+        ResearchQuestionRegistryError,
+        match="must remain not_operationalised",
+    ):
+        validate_accountability_payload(payload, registry)
+
+
+def test_cli_returns_nonzero_for_invalid_registry(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    def mutate(payload: dict[str, Any]) -> None:
+        payload["questions"][0]["status"] = "unknown"
+
+    invalid_path = _write_mutated_registry(tmp_path, mutate)
+    exit_code = validator_main(["--registry", str(invalid_path)])
+    captured = capsys.readouterr()
+
+    assert exit_code == 1
+    assert "[ERROR]" in captured.err


### PR DESCRIPTION
## Contribution declaration

### Current branch / base SHA

`research-question-registry` from exact `origin/main` SHA `560d3eb59105934c2e44139c406653f492b68443`.

### Relevant open PRs / overlapping files

- PR #241 owns live acquisition, archive, provider, protocol-projection, and related implementation paths. None of those implementation paths are changed here. Governance overlap is limited to `CHANGELOG.txt` and `MANIFEST_SOURCES.csv`.
- PR #264 owns generated outputs. No generated output is changed here.
- PR #258 owns gap outputs and gap implementation. No gap output or implementation path is changed here; `CHANGELOG.txt` is the only governance overlap.
- PR #259 also changes `CHANGELOG.txt`; PR #224 also changes `MANIFEST_SOURCES.csv`. These additive governance conflicts may require mechanical reconciliation after upstream merges.

### Objective

Add a proposed-for-review, machine-readable research-question registry and fail-closed validation for both the registry and future complete accountability ledgers.

### Paths in scope

- `config/research_question_registry.yml`
- `schemas/research_question_registry.schema.json`
- `schemas/research_question_accountability.schema.json`
- `src/scientific_sources/research_question_registry.py`
- `scripts/validate_research_question_registry.py`
- `tests/test_research_question_registry.py`
- `CHANGELOG.txt`
- `MANIFEST_SOURCES.csv`

### Source basis

The approved agenda wording comes from the maintainer-supplied 2026-08-09 RQ1-RQ8, RQ4.1-RQ4.4, and ETQ1-ETQ7 registry text. Repository operationalisation conventions come from `docs/STATISTICAL_ANALYSIS_PLAN.md`, schema-v2/cumulative database schemas, `outputs/cumulative_database/VARIABLE_LABELS.csv`, and the existing cumulative scientific database implementation.

### Authoritative scientific/configuration source

`config/live_query_protocol.yml` remains the sole authority for H1-H3 definitions, tests, required axes, declared outcomes, and result fields. The new registry stores only their ordered IDs/source and validates exact agreement; it does not duplicate definitions. The question registry status remains `proposed_for_review` because no repository evidence authorizes promotion to authoritative.

### Axis logic

The implementation preserves four separate canonical name/code pairs in order: `MARINE/M`, `MARITIME/T`, `OCEANIC/O`, and `HYDRONIZATION/H`. RQ4.1-RQ4.4 are mechanically bound to those pairs. Axis assignments cannot be inferred from query text or `source_query`.

### Expected artifact

A Layer 0 proposed registry with explicit construct, population, logical view kind, observational unit, variables, indicators, measures, denominator, missing/excluded handling, evidence boundary, method readiness, interpretation bounds, materialization status, and repository source basis for every operational RQ; explicit prerequisites for all ETQs; JSON Schemas and a typed CLI validator that reject invalid registries and incomplete or manufactured accountability ledgers.

### Acceptance criteria

- Exact approved RQ/ETQ wording and order are retained with globally unique IDs and valid parents.
- All four QMBD axes retain canonical name/code pairs.
- ETQ1-ETQ6 remain `not_operationalised`; ETQ7 remains `not_collected`.
- Planned/conditional methods cannot appear implemented without repository approval and an existing implementation reference.
- Logical views cannot appear materialized without a resolvable artifact.
- H1-H3 IDs exactly match the authoritative protocol and every future RQ8 ledger serializes all three in order.
- H2 remains `not_computable` without independently validated EQF 6-7 supply; generated designs never count as supply.
- Query text/`source_query` remain provenance only.
- Generated credentials, pathways, and outcomes remain design candidates, never validated supply.
- Future ledgers cover every RQ/ETQ and retain `not_computable`, `not_operationalised`, `not_collected`, and `review_required` states rather than omitting or manufacturing answers.

### Validation commands

Executed:

- `python -m pytest tests/test_research_question_registry.py -v` — 27 passed.
- `python -m flake8 src/scientific_sources/research_question_registry.py scripts/validate_research_question_registry.py tests/test_research_question_registry.py` — passed.
- `python -m mypy src/scientific_sources/research_question_registry.py scripts/validate_research_question_registry.py` — passed.
- `python -m flake8 src scripts tests run_full_analysis.py main.py` — passed.
- `python -m mypy src scripts run_full_analysis.py main.py` — passed for 76 source files; two informational unchecked-body notes in pre-existing `src/competence_mapper.py`.
- `python -m pytest tests/ -v` — 1604 passed, 2 expected skips.
- `python scripts/validate_research_question_registry.py` — passed: 12 RQs, 7 ETQs, 3 protocol hypotheses.
- `python scripts/validate_generated_outputs.py` — passed. The anticipated stale HYDRONIZATION failure did not reproduce on base SHA `560d3eb...`; no outputs were regenerated.
- `python scripts/validate_run_archive_integrity.py --archive-root outputs/run_archive --require-present` — passed for 3 archived runs.
- `python scripts/validate_research_source_outputs.py` — passed with one informational warning that `research_api_smoke_report.json` is absent.
- `python scripts/sync_audit.py` — passed with the expected pre-commit dirty-tree warning; outputs and manifest had no drift.
- `python scripts/generate_manifest.py` twice plus SHA-256 comparison and post-generation diff check — deterministic.
- `python scripts/changelog_guard.py` with all changed paths — passed.
- `git -c core.whitespace=cr-at-eol diff --cached --check` and actual merge-marker scan — passed. (`MANIFEST_SOURCES.csv` uses repository-standard CRLF output from the generator.)
- Independent high-confidence code review — no actionable findings.

Not executed:

- No live provider request, proprietary API call, or live acquisition run.
- No occurrence-ledger rebuild, identity migration, Jaccard change, generated empirical output regeneration, gap-output update, publication package, release, or merge.

### What changed, why, and which scientific aim it supports

The repository now has an executable accountability boundary linking theory/protocol references to RQs, constructs, variables, indicators, measures, evidence limits, methods, results, interpretations, and prohibited claims. The validator fails closed on duplicate IDs, invalid parents, noncanonical axes, unknown statuses, missing operational fields, unapproved implemented methods, unresolved materialized artifacts, protocol hypothesis drift, incomplete ledgers, omitted hypotheses, unsupported H2 outcomes, and manufactured answered states. This supports publication-oriented Blue Sociology traceability without claiming empirical results or validated credential supply.

---

## Sync & integration checklist

- [x] `python scripts/sync_audit.py` passes locally (expected dirty-tree warning before commit)
- [x] `python scripts/validate_generated_outputs.py` passes
- [x] `python scripts/validate_research_source_outputs.py` passes (one informational absent-smoke-report warning)
- [x] `CHANGELOG.txt` updated for substantive tracked changes
- [x] `MANIFEST_SOURCES.csv` regenerated and committed for new files
- [x] No unresolved merge conflict markers
- [x] Generated artifacts, manifests, and checksums remain complete where applicable

---

## Testing

### Negative regression coverage

- [x] Regressions cover duplicate IDs, invalid parents, noncanonical axes, unknown statuses, missing fields, false method implementation, false materialization, hypothesis mismatch, H2 supply misuse, incomplete ledgers, omitted baseline fields, and manufactured answered states.
- [x] Registry CLI and future-ledger validation paths are exercised.

### Executed validation

- [x] Full `python -m pytest tests/ -v` passes (1604 passed, 2 expected skips)
- [x] No new test failures introduced
- [x] This PR body states exactly what was and was not validated